### PR TITLE
feat: add full support of Query API (`pre-rc.20`)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,6 @@
   "commit": false,
   "fixed": [["@iroha2/crypto-target-*"], ["@iroha2/client", "@iroha2/data-model", "@iroha2/data-model-schema"]],
   "access": "restricted",
-  "baseBranch": "iroha2",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/eleven-toys-buy.md
+++ b/.changeset/eleven-toys-buy.md
@@ -1,0 +1,7 @@
+---
+'@iroha2/client': minor
+---
+
+**feat:** add full support of Query API, soft-deprecating previous improper implementation
+
+The new implementation is available via `Client.query`, `Torii.queryWithParams`, and `doQuery` functions.

--- a/.changeset/wild-snails-kick.md
+++ b/.changeset/wild-snails-kick.md
@@ -1,0 +1,5 @@
+---
+'@iroha2/client': minor
+---
+
+**feat:** soft-deprecate `computeTransactionHash`; add `computeTransactionPayloadHash` & `computeSignedTransactionHash` instead, with descriptions which one to use and when


### PR DESCRIPTION
## Queries

### Context

Existing Query API implementation in Iroha JS is not complete:

- It doesn't account for "Live Queries". Iroha by default returns query results as batches, and clients must make subsequent requests with the given `query_id` and `cursor` retrieve more results.
- It doesn't support pagination and sorting parameters.

### Solution

The new API looks like this:

```ts
// iterable query
const domains = client
  .query(pre, datamodel.QueryBox('FindDomains'), {
    // optional params
    start: 10,
    limit: 20,
    sortByMetadataKey: 'sorting-key'
  })
  .then((response) => response.as('Iter').all())

// singular query
const transaction = client
  .query(pre, datamodel.QueryBox(
    'FindTransactionByHash', 
    datamodel.FindTransactionByHash({ hash: ... })
  ))
  .then((response) => response.as('Value').enum.as('TransactionQueryOutput'))
```

The `response` is a enumeration of possible query responses:

- `Iter` for iterable query response. This is a live query, and it contains a handle to fetch subsequent batches of data. As in the example above, there is a helper method `.all(): Promise<Value[]>` that simply fetches all batches and collects them into a single array.
- `Value` for singular query response. This is returned by queries that return only a single result.
- `Failure` with decoded `ValidationFail` reason. 

## `computeTransactionHash`

While investigating #200, I found that the transaction hash emitted by pipeline events is different from the hash used for querying transactions: the first is `HashOf<TransactionPayload>`, and the second is `HashOf<SignedTransaction>`.

To reduce this ambiguity for SDK users, I soft-deprecated `computeTransactionHash` and added new helpers: `computeTransactionPayloadHash` and `computeSignedTransactionHash`.