### PR TITLE
Remove `JSR_TOKEN`, rely on OIDC

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,6 +108,9 @@ jobs:
     if: github.event_name == 'push'
     needs: [check]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache/restore@v4
@@ -126,6 +129,4 @@ jobs:
         with:
           deno-version: v2.x
       - name: Publish
-        run: deno task publish --token $JSR_TOKEN
-        env:
-          JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
+        run: deno task publish


### PR DESCRIPTION
It turns out JSR supports authorization via GitHub's OpenID Connect. Since I've just linked this repo in the packages' settings, everything should work without needing a token.

@BAStos525, you can remove the secret from the settings if this works.