### PR TITLE
chore: release 2025.02.19

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,14 @@
+### 2025.02.19
+
+#### @iroha/client 0.2.0 (major)
+
+- bump version to update @iroha/core dependency
+- docs(core, client): extend docs, link modules (#226)
+
+#### @iroha/core 0.2.1 (patch)
+
+- docs(core, client): extend docs, link modules (#226)
+
 ### 2025.02.18
 
 #### @iroha/core 0.2.0 (major)

--- a/packages/client/deno.jsonc
+++ b/packages/client/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "exports": {
     ".": "./mod.ts",
     "./web-socket": "./web-socket/mod.ts"

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "exports": {
     ".": "./mod.ts",
     "./codec": "./codec.ts",


### PR DESCRIPTION
This is necessary to publish `@iroha/client@0.2.0`. `0.1.0` relies on `@iroha/core@0.1.0` which is now archived.