### PR TITLE
chore: release 2025.04.16

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -7,7 +7,7 @@
 
 #### @iroha/core 0.4.0-beta.1 (prerelease)
 
-- refactor(core)!: support of wip `rc.2` (NFTs & empty blocks) (#251) 
+- refactor(core)!: support of wip `rc.2` (NFTs & empty blocks) (#251)
 - perf(core)!: optimise interop with crypto wasm, change some crypto apis (#248)
 
 ### 2025.03.13a

--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,15 @@
+### 2025.04.16
+
+#### @iroha/client 0.4.0-beta.1 (prerelease)
+
+- refactor(client)!: updated config endpoints (#251)
+- docs(client): remove redundant note about selectors design (#247)
+
+#### @iroha/core 0.4.0-beta.1 (prerelease)
+
+- refactor(core)!: support of wip `rc.2` (NFTs & empty blocks) (#251) 
+- perf(core)!: optimise interop with crypto wasm, change some crypto apis (#248)
+
 ### 2025.03.13a
 
 #### @iroha/core 0.3.1 (patch)

--- a/packages/client/deno.jsonc
+++ b/packages/client/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/client",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.1",
   "exports": {
     ".": "./mod.ts",
     "./web-socket": "./web-socket/mod.ts"

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/core",
-  "version": "0.3.1",
+  "version": "0.4.0-beta.1",
   "exports": {
     ".": "./mod.ts",
     "./codec": "./codec.ts",


### PR DESCRIPTION
Release `v0.4.0-beta.1` of SDK supporting the upcoming Iroha `v2.0.0-rc.2`.

Beta because there will be some more changes in Iroha a bit later.