### PR TITLE
refactor(client): move `.peers()` method from TelemetryAPI to MainAPI

### DIFF
--- a/packages/client/api.ts
+++ b/packages/client/api.ts
@@ -207,6 +207,22 @@ export class MainAPI {
     await ResponseError.assertStatus(response, 200)
     return response.json()
   }
+
+  public async peers(): Promise<PeerJson[]> {
+    const response = await this.http.getFetch()(urlJoinPath(this.http.toriiBaseURL, ENDPOINT_PEERS))
+    await ResponseError.assertStatus(response, 200)
+    return response.json().then(
+      // array of strings in format `<pub key multihash>@<socket addr>`
+      (ids: string[]) => {
+        assert(Array.isArray(ids))
+        return ids.map((id) => {
+          assert(typeof id === 'string')
+          const [pubkey, address] = id.split('@')
+          return { id: dm.PublicKey.fromMultihash(pubkey), address }
+        })
+      },
+    )
+  }
 }
 
 async function handleQueryResponse(resp: Response): Promise<dm.QueryResponse> {
@@ -246,23 +262,6 @@ export class TelemetryAPI {
     })
     await ResponseError.assertStatus(response, 200)
     return response.arrayBuffer().then((buffer) => getCodec(dm.Status).decode(new Uint8Array(buffer)))
-  }
-
-  // TODO: move once metrics are updated
-  public async peers(): Promise<PeerJson[]> {
-    const response = await this.http.getFetch()(urlJoinPath(this.http.toriiBaseURL, ENDPOINT_PEERS))
-    await ResponseError.assertStatus(response, 200)
-    return response.json().then(
-      // array of strings in format `<pub key multihash>@<socket addr>`
-      (ids: string[]) => {
-        assert(Array.isArray(ids))
-        return ids.map((id) => {
-          assert(typeof id === 'string')
-          const [pubkey, address] = id.split('@')
-          return { id: dm.PublicKey.fromMultihash(pubkey), address }
-        })
-      },
-    )
   }
 
   public async metrics(): Promise<string> {

--- a/tests/node/tests/client-apis.spec.ts
+++ b/tests/node/tests/client-apis.spec.ts
@@ -108,7 +108,7 @@ describe('Telemetry API methods', () => {
   test('peers (network of 4)', async () => {
     const { peers } = await useNetwork({ peers: 4, seed: new Uint8Array(Buffer.from('deadbeef', 'hex')) })
 
-    const peersData = await peers[0].client.api.telemetry.peers()
+    const peersData = await peers[0].client.api.peers()
 
     expect(peersData.map((x) => x.id.multihash())).contain.all.members(
       peers.slice(1).map((x) => x.keypair.publicKey().multihash()),


### PR DESCRIPTION
Close #252 