### PR TITLE
chore: release 2025.05.09

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,18 @@
+### 2025.05.09
+
+#### @iroha/client 0.4.0 (minor)
+
+- feat(core, client): include `commitTime` into `Status` (#258)
+- refactor(client): move `.peers()` method from TelemetryAPI to MainAPI (#259)
+
+#### @iroha/client-web-socket-node 0.4.0 (minor)
+
+- bump version to be compabible with `@iroha/client@^0.4.0`
+
+#### @iroha/core 0.4.0 (minor)
+
+- feat(core, client): include `commitTime` into `Status` (#258)
+
 ### 2025.04.16
 
 #### @iroha/client 0.4.0-beta.1 (prerelease)

--- a/packages/client-web-socket-node/deno.jsonc
+++ b/packages/client-web-socket-node/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/client-web-socket-node",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "exports": "./mod.ts",
   "imports": {
     "ws": "npm:ws@^8.18.0"

--- a/packages/client/deno.jsonc
+++ b/packages/client/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/client",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0",
   "exports": {
     ".": "./mod.ts",
     "./web-socket": "./web-socket/mod.ts"

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@iroha/core",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0",
   "exports": {
     ".": "./mod.ts",
     "./codec": "./codec.ts",


### PR DESCRIPTION
Release `0.4.0` versions of packages with support of Iroha `v2.0.0-rc.2.0`.

Also closes #254