### PR TITLE
feat!: support post-`2.0.0-rc.2.0` Iroha

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 env:
   IROHA_GIT: https://github.com/hyperledger-iroha/iroha.git
-  IROHA_REV: v2.0.0-rc.2.0
+  IROHA_REV: 884f870a791994cccd62da5febf246a1705eeb48
+  DENO_VERSION: v2.5.2
 jobs:
   prep-crypto-wasm:
     runs-on: ubuntu-latest
@@ -32,7 +33,7 @@ jobs:
       - uses: denoland/setup-deno@v2
         if: steps.prep-cache.outputs.cache-hit != 'true'
         with:
-          deno-version: v2.x
+          deno-version: ${{ env.DENO_VERSION }}
       - name: Build packages
         if: steps.prep-cache.outputs.cache-hit != 'true'
         run: deno task prep:crypto-wasm
@@ -50,14 +51,14 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         if: steps.prep-cache.outputs.cache-hit != 'true'
         with:
-          toolchain: 'nightly-2024-09-09'
+          toolchain: 'nightly-2025-05-08'
           target: 'wasm32-unknown-unknown'
           components: rust-src
           cache: 'false'
       - uses: denoland/setup-deno@v2
         if: steps.prep-cache.outputs.cache-hit != 'true'
         with:
-          deno-version: v2.x
+          deno-version: ${{ env.DENO_VERSION }}
       - name: Prepare Iroha artifacts
         if: steps.prep-cache.outputs.cache-hit != 'true'
         run: |
@@ -83,7 +84,7 @@ jobs:
             prep/crypto-wasm
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.2.x
+          deno-version: ${{ env.DENO_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -118,7 +119,7 @@ jobs:
             prep/crypto-wasm
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.2.x
+          deno-version: ${{ env.DENO_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/crypto-wasm/.cargo/config.toml
+++ b/crypto-wasm/.cargo/config.toml
@@ -1,2 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"
+
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'

--- a/crypto-wasm/rust-toolchain.toml
+++ b/crypto-wasm/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "nightly-2024-09-09"
+channel = "nightly-2025-05-08"
+targets = ["wasm32-unknown-unknown"]
+components = ["rust-src"]

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "license": "Apache 2.0",
   "nodeModulesDir": "auto",
-  "exclude": ["**/docs"],
+  "exclude": ["**/docs", "./tmp"],
   "workspace": [
     "./packages/core",
     "./packages/client",
@@ -35,7 +35,7 @@
       "dependencies": ["prep:ok"]
     },
     "test:deno": {
-      "command": "deno test -R --doc",
+      "command": "deno test -RE --doc",
       "dependencies": ["prep:ok"]
     },
     "test:integration:node": {
@@ -82,17 +82,23 @@
     }
   },
   "imports": {
+    "@david/dax": "jsr:@david/dax@^0.43.2",
     "@deno/vite-plugin": "npm:@deno/vite-plugin@^1.0.3",
     "@std/assert": "jsr:@std/assert@^1.0.11",
     "@std/async": "jsr:@std/async@^1.0.10",
-    "@std/encoding": "jsr:@std/encoding@^1.0.7",
+    "@std/cli": "jsr:@std/cli@^1.0.22",
+    "@std/crypto": "jsr:@std/crypto@^1.0.5",
+    "@std/encoding": "jsr:@std/encoding@^1.0.10",
     "@std/expect": "jsr:@std/expect@^1.0.13",
     "@std/fmt": "jsr:@std/fmt@^1.0.5",
+    "@std/fs": "jsr:@std/fs@^1.0.19",
+    "@std/path": "jsr:@std/path@^1.1.2",
     "@std/testing": "jsr:@std/testing@^1.0.9",
+    "@std/text": "jsr:@std/text@^1.0.16",
     "@std/toml": "jsr:@std/toml@^1.0.2",
     "change-case": "npm:change-case@^5.4.4",
     "dprint-node": "npm:dprint-node@^1.0.8",
-    "fast-equals": "npm:fast-equals@^5.2.2",
+    "fast-equals": "npm:fast-equals@^5.3.2",
     "get-port": "npm:get-port@^7.1.0",
     "immutable": "npm:immutable@^5.0.3",
     "jake": "npm:jake@^10.9.2",

--- a/deno.lock
+++ b/deno.lock
@@ -1,94 +1,95 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@david/dax@*": "0.42.0",
+    "jsr:@david/console-static-text@0.3": "0.3.0",
+    "jsr:@david/dax@~0.43.2": "0.43.2",
     "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@dprint/formatter@*": "0.4.1",
     "jsr:@iroha/core@0.3.1": "0.3.1",
     "jsr:@luca/cases@*": "1.0.0",
-    "jsr:@std/assert@0.221": "0.221.0",
-    "jsr:@std/assert@^1.0.10": "1.0.11",
-    "jsr:@std/assert@^1.0.11": "1.0.11",
-    "jsr:@std/async@^1.0.10": "1.0.10",
-    "jsr:@std/async@^1.0.9": "1.0.10",
-    "jsr:@std/bytes@0.221": "0.221.0",
+    "jsr:@std/assert@^1.0.11": "1.0.14",
+    "jsr:@std/assert@^1.0.13": "1.0.14",
+    "jsr:@std/assert@^1.0.14": "1.0.14",
+    "jsr:@std/async@^1.0.10": "1.0.14",
+    "jsr:@std/async@^1.0.13": "1.0.14",
+    "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/cli@*": "1.0.12",
+    "jsr:@std/cli@^1.0.22": "1.0.22",
     "jsr:@std/collections@^1.0.9": "1.0.10",
     "jsr:@std/crypto@*": "1.0.4",
-    "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/crypto@^1.0.5": "1.0.5",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@*": "1.0.7",
-    "jsr:@std/encoding@^1.0.7": "1.0.7",
-    "jsr:@std/expect@*": "1.0.13",
-    "jsr:@std/expect@^1.0.13": "1.0.13",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/encoding@^1.0.7": "1.0.10",
+    "jsr:@std/expect@^1.0.13": "1.0.17",
     "jsr:@std/fmt@*": "1.0.5",
     "jsr:@std/fmt@1": "1.0.5",
     "jsr:@std/fmt@^1.0.5": "1.0.5",
-    "jsr:@std/fs@*": "1.0.11",
-    "jsr:@std/fs@1": "1.0.11",
-    "jsr:@std/fs@^1.0.9": "1.0.11",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/io@0.221": "0.221.0",
+    "jsr:@std/fs@1": "1.0.19",
+    "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.9": "1.0.10",
+    "jsr:@std/io@0.225": "0.225.2",
     "jsr:@std/path@*": "1.0.8",
-    "jsr:@std/path@1": "1.0.8",
-    "jsr:@std/path@^1.0.8": "1.0.8",
-    "jsr:@std/streams@0.221": "0.221.0",
-    "jsr:@std/testing@*": "1.0.9",
-    "jsr:@std/testing@^1.0.9": "1.0.9",
+    "jsr:@std/path@1": "1.1.2",
+    "jsr:@std/path@^1.1.1": "1.1.2",
+    "jsr:@std/path@^1.1.2": "1.1.2",
+    "jsr:@std/regexp@^1.0.1": "1.0.1",
+    "jsr:@std/testing@^1.0.9": "1.0.15",
     "jsr:@std/text@*": "1.0.10",
+    "jsr:@std/text@^1.0.16": "1.0.16",
     "jsr:@std/toml@*": "1.0.2",
     "jsr:@std/toml@^1.0.2": "1.0.2",
-    "npm:@bahmutov/cypress-esbuild-preprocessor@^2.2.0": "2.2.4_esbuild@0.24.2",
-    "npm:@deno/vite-plugin@^1.0.3": "1.0.3_vite@6.1.0__sass@1.84.0_sass@1.84.0",
+    "npm:@bahmutov/cypress-esbuild-preprocessor@^2.2.0": "2.2.6_esbuild@0.24.2",
+    "npm:@deno/vite-plugin@^1.0.3": "1.0.5_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0",
     "npm:@dprint/typescript@*": "0.93.3",
     "npm:@scale-codec/core@^2.0.1": "2.0.1",
-    "npm:@types/node@*": "22.5.4",
-    "npm:@vitejs/plugin-vue@^5.0.4": "5.2.1_vite@6.1.0__sass@1.84.0_vue@3.5.13_sass@1.84.0",
-    "npm:@vue-kakuyaku/core@~0.4.3": "0.4.3_vue@3.5.13",
-    "npm:@vueuse/core@^8.0.1": "8.9.4_vue@3.5.13",
+    "npm:@types/node@*": "24.2.0",
+    "npm:@vitejs/plugin-vue@^5.0.4": "5.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_vue@3.5.22_sass@1.93.2_@types+node@24.2.0",
+    "npm:@vue-kakuyaku/core@~0.4.3": "0.4.3_vue@3.5.22",
+    "npm:@vueuse/core@^8.0.1": "8.9.4_vue@3.5.22",
     "npm:change-case@^5.4.4": "5.4.4",
     "npm:cypress@^13.12.0": "13.17.0_enquirer@2.4.1",
-    "npm:debug@*": "4.4.0",
-    "npm:debug@^4.4.0": "4.4.0",
+    "npm:debug@^4.4.0": "4.4.3",
     "npm:dprint-node@^1.0.8": "1.0.8",
     "npm:emittery@^1.1.0": "1.1.0",
     "npm:esbuild@~0.24.2": "0.24.2",
-    "npm:fast-equals@*": "5.2.2",
-    "npm:fast-equals@^5.2.2": "5.2.2",
+    "npm:fast-equals@^5.3.2": "5.3.2",
     "npm:get-port@^7.1.0": "7.1.0",
-    "npm:h3@^1.15.0": "1.15.0",
-    "npm:immutable@^5.0.3": "5.0.3",
-    "npm:jake@^10.9.2": "10.9.2",
+    "npm:h3@^1.15.0": "1.15.4",
+    "npm:immutable@^5.0.3": "5.1.3",
+    "npm:jake@^10.9.2": "10.9.4",
     "npm:json5@*": "2.2.3",
     "npm:listhen@^1.9.0": "1.9.0",
     "npm:npm-run-all@^4.1.5": "4.1.5",
     "npm:p-defer@^4.0.1": "4.0.1",
     "npm:remeda@^2.20.1": "2.20.1",
-    "npm:sass@^1.52.1": "1.84.0",
+    "npm:sass@^1.52.1": "1.93.2",
     "npm:tempy@^3.1.0": "3.1.0",
     "npm:ts-pattern@^5.6.2": "5.6.2",
     "npm:type-fest@^4.33.0": "4.33.0",
-    "npm:vite-plugin-wasm@^3.4.1": "3.4.1_vite@6.1.0__sass@1.84.0_@types+node@22.5.4_sass@1.84.0",
-    "npm:vite@*": "6.1.0_@types+node@22.5.4_sass@1.84.0",
-    "npm:vite@^6.1.0": "6.1.0_@types+node@22.5.4_sass@1.84.0",
-    "npm:vitest@*": "3.0.5_vite@6.1.0__sass@1.84.0_sass@1.84.0",
-    "npm:vitest@3.0.5": "3.0.5_vite@6.1.0__sass@1.84.0_sass@1.84.0",
-    "npm:vitest@^3.0.5": "3.0.5_vite@6.1.0__sass@1.84.0_sass@1.84.0",
-    "npm:vue@^3.2.47": "3.5.13",
+    "npm:vite@^6.1.0": "6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0",
+    "npm:vitest@^3.0.5": "3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0",
+    "npm:vue@^3.2.47": "3.5.22",
     "npm:ws@^8.18.0": "8.18.0",
-    "npm:zx@^8.3.2": "8.3.2"
+    "npm:zx@^8.3.2": "8.8.4"
   },
   "jsr": {
-    "@david/dax@0.42.0": {
-      "integrity": "0c547c9a20577a6072b90def194c159c9ddab82280285ebfd8268a4ebefbd80b",
+    "@david/console-static-text@0.3.0": {
+      "integrity": "2dfb46ecee525755f7989f94ece30bba85bd8ffe3e8666abc1bf926e1ee0698d"
+    },
+    "@david/dax@0.43.2": {
+      "integrity": "8c7df175465d994c0e3568e3eb91102768c2f1c86d2a513d7fc4cab13f9cb328",
       "dependencies": [
+        "jsr:@david/console-static-text",
         "jsr:@david/path",
         "jsr:@david/which",
         "jsr:@std/fmt@1",
         "jsr:@std/fs@1",
         "jsr:@std/io",
-        "jsr:@std/path@1",
-        "jsr:@std/streams"
+        "jsr:@std/path@1"
       ]
     },
     "@david/path@0.2.0": {
@@ -115,23 +116,23 @@
     "@luca/cases@1.0.0": {
       "integrity": "b5f9471f1830595e63a2b7d62821ac822a19e16899e6584799be63f17a1fbc30"
     },
-    "@std/assert@0.221.0": {
-      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
-    },
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.10"
       ]
     },
-    "@std/async@1.0.10": {
-      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    "@std/async@1.0.14": {
+      "integrity": "62e954a418652c704d37563a3e54a37d4cf0268a9dcaeac1660cc652880b5326"
     },
-    "@std/bytes@0.221.0": {
-      "integrity": "64a047011cf833890a4a2ab7293ac55a1b4f5a050624ebc6a0159c357de91966"
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
     "@std/cli@1.0.12": {
       "integrity": "e5cfb7814d189da174ecd7a34fbbd63f3513e24a1b307feb2fcd5da47a070d90"
+    },
+    "@std/cli@1.0.22": {
+      "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
     },
     "@std/collections@1.0.10": {
       "integrity": "903af106a3d92970d74e20f7ebff77d9658af9bef4403f1dc42a7801c0575899"
@@ -139,60 +140,78 @@
     "@std/crypto@1.0.4": {
       "integrity": "cee245c453bd5366207f4d8aa25ea3e9c86cecad2be3fefcaa6cb17203d79340"
     },
-    "@std/data-structures@1.0.6": {
-      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    "@std/crypto@1.0.5": {
+      "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
+    },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
     "@std/encoding@1.0.7": {
       "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
     },
-    "@std/expect@1.0.13": {
-      "integrity": "d8e236c7089cd9fcf5e6032f27dadc3db6349d0aee48c15bc71d717bca5baa42",
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
+    "@std/expect@1.0.17": {
+      "integrity": "316b47dd65c33e3151344eb3267bf42efba17d1415425f07ed96185d67fc04d9",
       "dependencies": [
-        "jsr:@std/assert@^1.0.11",
-        "jsr:@std/internal"
+        "jsr:@std/assert@^1.0.14",
+        "jsr:@std/internal@^1.0.10"
       ]
     },
     "@std/fmt@1.0.5": {
       "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
     },
-    "@std/fs@1.0.11": {
-      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd",
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
       "dependencies": [
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/internal@^1.0.9",
+        "jsr:@std/path@^1.1.1"
       ]
     },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
-    "@std/io@0.221.0": {
-      "integrity": "faf7f8700d46ab527fa05cc6167f4b97701a06c413024431c6b4d207caa010da",
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
+    "@std/io@0.225.2": {
+      "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7",
       "dependencies": [
-        "jsr:@std/assert@0.221",
         "jsr:@std/bytes"
       ]
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
-    "@std/streams@0.221.0": {
-      "integrity": "47f2f74634b47449277c0ee79fe878da4424b66bd8975c032e3afdca88986e61",
+    "@std/path@1.1.2": {
+      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
       "dependencies": [
-        "jsr:@std/io"
+        "jsr:@std/internal@^1.0.10"
       ]
     },
-    "@std/testing@1.0.9": {
-      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
+    "@std/regexp@1.0.1": {
+      "integrity": "5179d823465085c5480dafb44438466e83c424fadc61ba31f744050ecc0f596d"
+    },
+    "@std/testing@1.0.15": {
+      "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
       "dependencies": [
-        "jsr:@std/assert@^1.0.10",
-        "jsr:@std/async@^1.0.9",
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/async@^1.0.13",
         "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.9",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/fs@^1.0.19",
+        "jsr:@std/internal@^1.0.10",
+        "jsr:@std/path@^1.1.1"
       ]
     },
     "@std/text@1.0.10": {
       "integrity": "9dcab377450253c0efa9a9a0c731040bfd4e1c03f8303b5934381467b7954338"
+    },
+    "@std/text@1.0.16": {
+      "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8",
+      "dependencies": [
+        "jsr:@std/regexp"
+      ]
     },
     "@std/toml@1.0.2": {
       "integrity": "5892ba489c5b512265a384238a8fe8dddbbb9498b4b210ef1b9f0336a423a39b",
@@ -202,37 +221,38 @@
     }
   },
   "npm": {
-    "@babel/helper-string-parser@7.25.9": {
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="
+    "@babel/helper-string-parser@7.27.1": {
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
     },
-    "@babel/helper-validator-identifier@7.25.9": {
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
+    "@babel/helper-validator-identifier@7.27.1": {
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="
     },
-    "@babel/parser@7.26.7": {
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+    "@babel/parser@7.28.4": {
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dependencies": [
         "@babel/types"
-      ]
+      ],
+      "bin": true
     },
-    "@babel/types@7.26.7": {
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+    "@babel/types@7.28.4": {
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
       ]
     },
-    "@bahmutov/cypress-esbuild-preprocessor@2.2.4_esbuild@0.24.2": {
-      "integrity": "sha512-t5xOKK+a6PlsxgRBtZDzayUcPJGDLKJt1pwKK/Y8szuDPPF+DbEsrqL8fbKgE1+koPvOVaYMX4ggwQwqfk99hA==",
+    "@bahmutov/cypress-esbuild-preprocessor@2.2.6_esbuild@0.24.2": {
+      "integrity": "sha512-njJI3neexUcRh3iK/hXRZLwGa7tsjzO87MsoXkmqx0lmNaasJzewTau8hW6K9Tt74smA57e/uuskBUqU9SYrGw==",
       "dependencies": [
-        "debug@4.4.0",
-        "esbuild"
+        "debug@4.4.3",
+        "esbuild@0.24.2"
       ]
     },
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
-    "@cypress/request@3.0.7": {
-      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
+    "@cypress/request@3.0.9": {
+      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
       "dependencies": [
         "aws-sign2",
         "aws4",
@@ -261,143 +281,360 @@
         "lodash.once"
       ]
     },
-    "@deno/vite-plugin@1.0.3_vite@6.1.0__sass@1.84.0_sass@1.84.0": {
-      "integrity": "sha512-As059Zjde6oaUw7+WXhu2WpnjnBzjUCs5+j21S1ilQRIorN+sCrArXpdSDsCXXnHQbCU1SHjVrjcca49YOuwIg==",
+    "@deno/vite-plugin@1.0.5_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2": {
+      "integrity": "sha512-tLja5n4dyMhcze1NzvSs2iiriBymfBlDCZIrjMTxb9O2ru0gvmV6mn5oBD2teNw5Sd92cj3YJzKwsAs8tMJXlg==",
       "dependencies": [
-        "vite@6.1.0_sass@1.84.0"
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3"
+      ]
+    },
+    "@deno/vite-plugin@1.0.5_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0": {
+      "integrity": "sha512-tLja5n4dyMhcze1NzvSs2iiriBymfBlDCZIrjMTxb9O2ru0gvmV6mn5oBD2teNw5Sd92cj3YJzKwsAs8tMJXlg==",
+      "dependencies": [
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0"
       ]
     },
     "@dprint/typescript@0.93.3": {
       "integrity": "sha512-P/AAHYDyUG+5hih8knuk3s9n2wrCD1LSh0YsLlJMx6+v0Wsjf0PpcVRn+xDvHCtwPUctB5WBkZT2U8mu6Cm7RQ=="
     },
     "@esbuild/aix-ppc64@0.24.2": {
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/aix-ppc64@0.25.10": {
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/android-arm64@0.24.2": {
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm64@0.25.10": {
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@esbuild/android-arm@0.24.2": {
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-arm@0.25.10": {
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
     "@esbuild/android-x64@0.24.2": {
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/android-x64@0.25.10": {
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "os": ["android"],
+      "cpu": ["x64"]
     },
     "@esbuild/darwin-arm64@0.24.2": {
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-arm64@0.25.10": {
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@esbuild/darwin-x64@0.24.2": {
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-x64@0.25.10": {
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@esbuild/freebsd-arm64@0.24.2": {
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-arm64@0.25.10": {
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/freebsd-x64@0.24.2": {
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-x64@0.25.10": {
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/linux-arm64@0.24.2": {
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm64@0.25.10": {
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@esbuild/linux-arm@0.24.2": {
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-arm@0.25.10": {
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@esbuild/linux-ia32@0.24.2": {
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-ia32@0.25.10": {
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
     },
     "@esbuild/linux-loong64@0.24.2": {
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-loong64@0.25.10": {
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
     "@esbuild/linux-mips64el@0.24.2": {
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-mips64el@0.25.10": {
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
     },
     "@esbuild/linux-ppc64@0.24.2": {
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-ppc64@0.25.10": {
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
     "@esbuild/linux-riscv64@0.24.2": {
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-riscv64@0.25.10": {
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
     "@esbuild/linux-s390x@0.24.2": {
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-s390x@0.25.10": {
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
     "@esbuild/linux-x64@0.24.2": {
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-x64@0.25.10": {
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@esbuild/netbsd-arm64@0.24.2": {
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-arm64@0.25.10": {
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/netbsd-x64@0.24.2": {
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-x64@0.25.10": {
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
     },
     "@esbuild/openbsd-arm64@0.24.2": {
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-arm64@0.25.10": {
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
     },
     "@esbuild/openbsd-x64@0.24.2": {
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-x64@0.25.10": {
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.25.10": {
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
     },
     "@esbuild/sunos-x64@0.24.2": {
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/sunos-x64@0.25.10": {
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
     },
     "@esbuild/win32-arm64@0.24.2": {
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-arm64@0.25.10": {
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@esbuild/win32-ia32@0.24.2": {
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-ia32@0.25.10": {
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@esbuild/win32-x64@0.24.2": {
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
-    "@jridgewell/sourcemap-codec@1.5.0": {
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+    "@esbuild/win32-x64@0.25.10": {
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@jridgewell/sourcemap-codec@1.5.5": {
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@parcel/watcher-android-arm64@2.5.1": {
-      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
     "@parcel/watcher-darwin-arm64@2.5.1": {
-      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw=="
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
     "@parcel/watcher-darwin-x64@2.5.1": {
-      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg=="
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
     "@parcel/watcher-freebsd-x64@2.5.1": {
-      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ=="
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
     "@parcel/watcher-linux-arm-glibc@2.5.1": {
-      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA=="
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@parcel/watcher-linux-arm-musl@2.5.1": {
-      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q=="
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
     "@parcel/watcher-linux-arm64-glibc@2.5.1": {
-      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w=="
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@parcel/watcher-linux-arm64-musl@2.5.1": {
-      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg=="
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
     "@parcel/watcher-linux-x64-glibc@2.5.1": {
-      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A=="
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@parcel/watcher-linux-x64-musl@2.5.1": {
-      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg=="
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
     "@parcel/watcher-wasm@2.5.1": {
       "integrity": "sha512-RJxlQQLkaMMIuWRozy+z2vEqbaQlCuaCgVZIUCzQLYggY22LZbP5Y1+ia+FD724Ids9e+XIyOLXLrLgQSHIthw==",
       "dependencies": [
         "is-glob",
-        "micromatch",
-        "napi-wasm"
+        "micromatch"
       ]
     },
     "@parcel/watcher-win32-arm64@2.5.1": {
-      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw=="
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
     },
     "@parcel/watcher-win32-ia32@2.5.1": {
-      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
     },
     "@parcel/watcher-win32-x64@2.5.1": {
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@parcel/watcher@2.5.1": {
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dependencies": [
+        "detect-libc",
+        "is-glob",
+        "micromatch",
+        "node-addon-api"
+      ],
+      "optionalDependencies": [
         "@parcel/watcher-android-arm64",
         "@parcel/watcher-darwin-arm64",
         "@parcel/watcher-darwin-x64",
@@ -410,69 +647,119 @@
         "@parcel/watcher-linux-x64-musl",
         "@parcel/watcher-win32-arm64",
         "@parcel/watcher-win32-ia32",
-        "@parcel/watcher-win32-x64",
-        "detect-libc",
-        "is-glob",
-        "micromatch",
-        "node-addon-api"
-      ]
+        "@parcel/watcher-win32-x64"
+      ],
+      "scripts": true
     },
-    "@rollup/rollup-android-arm-eabi@4.34.4": {
-      "integrity": "sha512-gGi5adZWvjtJU7Axs//CWaQbQd/vGy8KGcnEaCWiyCqxWYDxwIlAHFuSe6Guoxtd0SRvSfVTDMPd5H+4KE2kKA=="
+    "@rollup/rollup-android-arm-eabi@4.52.4": {
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "os": ["android"],
+      "cpu": ["arm"]
     },
-    "@rollup/rollup-android-arm64@4.34.4": {
-      "integrity": "sha512-1aRlh1gqtF7vNPMnlf1vJKk72Yshw5zknR/ZAVh7zycRAGF2XBMVDAHmFQz/Zws5k++nux3LOq/Ejj1WrDR6xg=="
+    "@rollup/rollup-android-arm64@4.52.4": {
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "os": ["android"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-darwin-arm64@4.34.4": {
-      "integrity": "sha512-drHl+4qhFj+PV/jrQ78p9ch6A0MfNVZScl/nBps5a7u01aGf/GuBRrHnRegA9bP222CBDfjYbFdjkIJ/FurvSQ=="
+    "@rollup/rollup-darwin-arm64@4.52.4": {
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-darwin-x64@4.34.4": {
-      "integrity": "sha512-hQqq/8QALU6t1+fbNmm6dwYsa0PDD4L5r3TpHx9dNl+aSEMnIksHZkSO3AVH+hBMvZhpumIGrTFj8XCOGuIXjw=="
+    "@rollup/rollup-darwin-x64@4.52.4": {
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
     },
-    "@rollup/rollup-freebsd-arm64@4.34.4": {
-      "integrity": "sha512-/L0LixBmbefkec1JTeAQJP0ETzGjFtNml2gpQXA8rpLo7Md+iXQzo9kwEgzyat5Q+OG/C//2B9Fx52UxsOXbzw=="
+    "@rollup/rollup-freebsd-arm64@4.52.4": {
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-freebsd-x64@4.34.4": {
-      "integrity": "sha512-6Rk3PLRK+b8L/M6m/x6Mfj60LhAUcLJ34oPaxufA+CfqkUrDoUPQYFdRrhqyOvtOKXLJZJwxlOLbQjNYQcRQfw=="
+    "@rollup/rollup-freebsd-x64@4.52.4": {
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
     },
-    "@rollup/rollup-linux-arm-gnueabihf@4.34.4": {
-      "integrity": "sha512-kmT3x0IPRuXY/tNoABp2nDvI9EvdiS2JZsd4I9yOcLCCViKsP0gB38mVHOhluzx+SSVnM1KNn9k6osyXZhLoCA=="
+    "@rollup/rollup-linux-arm-gnueabihf@4.52.4": {
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
-    "@rollup/rollup-linux-arm-musleabihf@4.34.4": {
-      "integrity": "sha512-3iSA9tx+4PZcJH/Wnwsvx/BY4qHpit/u2YoZoXugWVfc36/4mRkgGEoRbRV7nzNBSCOgbWMeuQ27IQWgJ7tRzw=="
+    "@rollup/rollup-linux-arm-musleabihf@4.52.4": {
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "os": ["linux"],
+      "cpu": ["arm"]
     },
-    "@rollup/rollup-linux-arm64-gnu@4.34.4": {
-      "integrity": "sha512-7CwSJW+sEhM9sESEk+pEREF2JL0BmyCro8UyTq0Kyh0nu1v0QPNY3yfLPFKChzVoUmaKj8zbdgBxUhBRR+xGxg=="
+    "@rollup/rollup-linux-arm64-gnu@4.52.4": {
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-linux-arm64-musl@4.34.4": {
-      "integrity": "sha512-GZdafB41/4s12j8Ss2izofjeFXRAAM7sHCb+S4JsI9vaONX/zQ8cXd87B9MRU/igGAJkKvmFmJJBeeT9jJ5Cbw=="
+    "@rollup/rollup-linux-arm64-musl@4.52.4": {
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-linux-loongarch64-gnu@4.34.4": {
-      "integrity": "sha512-uuphLuw1X6ur11675c2twC6YxbzyLSpWggvdawTUamlsoUv81aAXRMPBC1uvQllnBGls0Qt5Siw8reSIBnbdqQ=="
+    "@rollup/rollup-linux-loong64-gnu@4.52.4": {
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
     },
-    "@rollup/rollup-linux-powerpc64le-gnu@4.34.4": {
-      "integrity": "sha512-KvLEw1os2gSmD6k6QPCQMm2T9P2GYvsMZMRpMz78QpSoEevHbV/KOUbI/46/JRalhtSAYZBYLAnT9YE4i/l4vg=="
+    "@rollup/rollup-linux-ppc64-gnu@4.52.4": {
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
     },
-    "@rollup/rollup-linux-riscv64-gnu@4.34.4": {
-      "integrity": "sha512-wcpCLHGM9yv+3Dql/CI4zrY2mpQ4WFergD3c9cpRowltEh5I84pRT/EuHZsG0In4eBPPYthXnuR++HrFkeqwkA=="
+    "@rollup/rollup-linux-riscv64-gnu@4.52.4": {
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
-    "@rollup/rollup-linux-s390x-gnu@4.34.4": {
-      "integrity": "sha512-nLbfQp2lbJYU8obhRQusXKbuiqm4jSJteLwfjnunDT5ugBKdxqw1X9KWwk8xp1OMC6P5d0WbzxzhWoznuVK6XA=="
+    "@rollup/rollup-linux-riscv64-musl@4.52.4": {
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
     },
-    "@rollup/rollup-linux-x64-gnu@4.34.4": {
-      "integrity": "sha512-JGejzEfVzqc/XNiCKZj14eb6s5w8DdWlnQ5tWUbs99kkdvfq9btxxVX97AaxiUX7xJTKFA0LwoS0KU8C2faZRg=="
+    "@rollup/rollup-linux-s390x-gnu@4.52.4": {
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
     },
-    "@rollup/rollup-linux-x64-musl@4.34.4": {
-      "integrity": "sha512-/iFIbhzeyZZy49ozAWJ1ZR2KW6ZdYUbQXLT4O5n1cRZRoTpwExnHLjlurDXXPKEGxiAg0ujaR9JDYKljpr2fDg=="
+    "@rollup/rollup-linux-x64-gnu@4.52.4": {
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
-    "@rollup/rollup-win32-arm64-msvc@4.34.4": {
-      "integrity": "sha512-qORc3UzoD5UUTneiP2Afg5n5Ti1GAW9Gp5vHPxzvAFFA3FBaum9WqGvYXGf+c7beFdOKNos31/41PRMUwh1tpA=="
+    "@rollup/rollup-linux-x64-musl@4.52.4": {
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
     },
-    "@rollup/rollup-win32-ia32-msvc@4.34.4": {
-      "integrity": "sha512-5g7E2PHNK2uvoD5bASBD9aelm44nf1w4I5FEI7MPHLWcCSrR8JragXZWgKPXk5i2FU3JFfa6CGZLw2RrGBHs2Q=="
+    "@rollup/rollup-openharmony-arm64@4.52.4": {
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
     },
-    "@rollup/rollup-win32-x64-msvc@4.34.4": {
-      "integrity": "sha512-p0scwGkR4kZ242xLPBuhSckrJ734frz6v9xZzD+kHVYRAkSUmdSLCIJRfql6H5//aF8Q10K+i7q8DiPfZp0b7A=="
+    "@rollup/rollup-win32-arm64-msvc@4.52.4": {
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@rollup/rollup-win32-ia32-msvc@4.52.4": {
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@rollup/rollup-win32-x64-gnu@4.52.4": {
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@rollup/rollup-win32-x64-msvc@4.52.4": {
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@scale-codec/core@2.0.1": {
       "integrity": "sha512-3Ei7Gf3wNDrP5l7W/dEF9Q7Py1ttdNTFulzNNdFrqBw8v1khyC7SZIcYpsbAJ5uo/PDIhhK4FKOrK467I0vv4Q==",
@@ -487,39 +774,29 @@
     "@scale-codec/util@1.1.2": {
       "integrity": "sha512-Aali9gWoI1vOUUwk2H1FktstiInl6x5rjrPd3Am/b1WJV603NEI9QcJ7UGM7Eh42UjLD9e6H7E1ZF0yFnlRUUQ=="
     },
-    "@types/estree@1.0.6": {
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
-    },
-    "@types/fs-extra@11.0.4": {
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+    "@types/chai@5.2.2": {
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
       "dependencies": [
-        "@types/jsonfile",
-        "@types/node@22.5.4"
+        "@types/deep-eql"
       ]
     },
-    "@types/jsonfile@6.1.4": {
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dependencies": [
-        "@types/node@22.5.4"
-      ]
+    "@types/deep-eql@4.0.2": {
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
-    "@types/node@22.13.1": {
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
-      "dependencies": [
-        "undici-types@6.20.0"
-      ]
+    "@types/estree@1.0.8": {
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+    "@types/node@24.2.0": {
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": [
-        "undici-types@6.19.8"
+        "undici-types"
       ]
     },
     "@types/sinonjs__fake-timers@8.1.1": {
       "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g=="
     },
-    "@types/sizzle@2.3.9": {
-      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w=="
+    "@types/sizzle@2.3.10": {
+      "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww=="
     },
     "@types/web-bluetooth@0.0.14": {
       "integrity": "sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A=="
@@ -527,70 +804,94 @@
     "@types/yauzl@2.10.3": {
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dependencies": [
-        "@types/node@22.5.4"
+        "@types/node"
       ]
     },
-    "@vitejs/plugin-vue@5.2.1_vite@6.1.0__sass@1.84.0_vue@3.5.13_sass@1.84.0": {
-      "integrity": "sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==",
+    "@vitejs/plugin-vue@5.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_vue@3.5.22_sass@1.93.2": {
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
       "dependencies": [
-        "vite@6.1.0_sass@1.84.0",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3",
         "vue"
       ]
     },
-    "@vitest/expect@3.0.5": {
-      "integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
+    "@vitejs/plugin-vue@5.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_vue@3.5.22_sass@1.93.2_@types+node@24.2.0": {
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
       "dependencies": [
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0",
+        "vue"
+      ]
+    },
+    "@vitest/expect@3.2.4": {
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dependencies": [
+        "@types/chai",
         "@vitest/spy",
         "@vitest/utils",
         "chai",
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@3.0.5_vite@6.1.0__sass@1.84.0_sass@1.84.0": {
-      "integrity": "sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==",
+    "@vitest/mocker@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2": {
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker@3.0.3",
         "magic-string",
-        "vite@6.1.0_sass@1.84.0"
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3"
+      ],
+      "optionalPeers": [
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3"
       ]
     },
-    "@vitest/pretty-format@3.0.5": {
-      "integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
+    "@vitest/mocker@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0": {
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dependencies": [
+        "@vitest/spy",
+        "estree-walker@3.0.3",
+        "magic-string",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0"
+      ],
+      "optionalPeers": [
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0"
+      ]
+    },
+    "@vitest/pretty-format@3.2.4": {
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dependencies": [
         "tinyrainbow"
       ]
     },
-    "@vitest/runner@3.0.5": {
-      "integrity": "sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==",
+    "@vitest/runner@3.2.4": {
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dependencies": [
         "@vitest/utils",
-        "pathe@2.0.2"
+        "pathe@2.0.3",
+        "strip-literal"
       ]
     },
-    "@vitest/snapshot@3.0.5": {
-      "integrity": "sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==",
+    "@vitest/snapshot@3.2.4": {
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dependencies": [
         "@vitest/pretty-format",
         "magic-string",
-        "pathe@2.0.2"
+        "pathe@2.0.3"
       ]
     },
-    "@vitest/spy@3.0.5": {
-      "integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
+    "@vitest/spy@3.2.4": {
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dependencies": [
         "tinyspy"
       ]
     },
-    "@vitest/utils@3.0.5": {
-      "integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
+    "@vitest/utils@3.2.4": {
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dependencies": [
         "@vitest/pretty-format",
         "loupe",
         "tinyrainbow"
       ]
     },
-    "@vue-kakuyaku/core@0.4.3_vue@3.5.13": {
+    "@vue-kakuyaku/core@0.4.3_vue@3.5.22": {
       "integrity": "sha512-1+H3+7FA9/WocTV+jAlrnCD08sY5BtrKQ1Opvjkz4E5MRQaaIhiU5jF/tAgO1e25b+Q/01C8BiWX4a3bMgGIqw==",
       "dependencies": [
         "@vueuse/core",
@@ -598,8 +899,8 @@
         "vue"
       ]
     },
-    "@vue/compiler-core@3.5.13": {
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+    "@vue/compiler-core@3.5.22": {
+      "integrity": "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==",
       "dependencies": [
         "@babel/parser",
         "@vue/shared",
@@ -608,15 +909,15 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-dom@3.5.13": {
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+    "@vue/compiler-dom@3.5.22": {
+      "integrity": "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==",
       "dependencies": [
         "@vue/compiler-core",
         "@vue/shared"
       ]
     },
-    "@vue/compiler-sfc@3.5.13": {
-      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+    "@vue/compiler-sfc@3.5.22": {
+      "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
       "dependencies": [
         "@babel/parser",
         "@vue/compiler-core",
@@ -629,28 +930,28 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-ssr@3.5.13": {
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+    "@vue/compiler-ssr@3.5.22": {
+      "integrity": "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/shared"
       ]
     },
-    "@vue/reactivity@3.5.13": {
-      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+    "@vue/reactivity@3.5.22": {
+      "integrity": "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==",
       "dependencies": [
         "@vue/shared"
       ]
     },
-    "@vue/runtime-core@3.5.13": {
-      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+    "@vue/runtime-core@3.5.22": {
+      "integrity": "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/shared"
       ]
     },
-    "@vue/runtime-dom@3.5.13": {
-      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+    "@vue/runtime-dom@3.5.22": {
+      "integrity": "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/runtime-core",
@@ -658,18 +959,18 @@
         "csstype"
       ]
     },
-    "@vue/server-renderer@3.5.13_vue@3.5.13": {
-      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+    "@vue/server-renderer@3.5.22_vue@3.5.22": {
+      "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
       "dependencies": [
         "@vue/compiler-ssr",
         "@vue/shared",
         "vue"
       ]
     },
-    "@vue/shared@3.5.13": {
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
+    "@vue/shared@3.5.22": {
+      "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w=="
     },
-    "@vueuse/core@8.9.4_vue@3.5.13": {
+    "@vueuse/core@8.9.4_vue@3.5.22": {
       "integrity": "sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==",
       "dependencies": [
         "@types/web-bluetooth",
@@ -677,20 +978,27 @@
         "@vueuse/shared",
         "vue",
         "vue-demi"
+      ],
+      "optionalPeers": [
+        "vue"
       ]
     },
     "@vueuse/metadata@8.9.4": {
       "integrity": "sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw=="
     },
-    "@vueuse/shared@8.9.4_vue@3.5.13": {
+    "@vueuse/shared@8.9.4_vue@3.5.22": {
       "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
       "dependencies": [
         "vue",
         "vue-demi"
+      ],
+      "optionalPeers": [
+        "vue"
       ]
     },
-    "acorn@8.14.0": {
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+    "acorn@8.15.0": {
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "bin": true
     },
     "aggregate-error@3.1.0": {
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
@@ -802,15 +1110,15 @@
     "bluebird@3.7.2": {
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
-    "brace-expansion@1.1.11": {
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "brace-expansion@1.1.12": {
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": [
         "balanced-match",
         "concat-map"
       ]
     },
-    "brace-expansion@2.0.1": {
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "brace-expansion@2.0.2": {
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": [
         "balanced-match"
       ]
@@ -837,8 +1145,8 @@
     "cachedir@2.4.0": {
       "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ=="
     },
-    "call-bind-apply-helpers@1.0.1": {
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dependencies": [
         "es-errors",
         "function-bind"
@@ -853,8 +1161,8 @@
         "set-function-length"
       ]
     },
-    "call-bound@1.0.3": {
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dependencies": [
         "call-bind-apply-helpers",
         "get-intrinsic"
@@ -863,8 +1171,8 @@
     "caseless@0.12.0": {
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
-    "chai@5.1.2": {
-      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+    "chai@5.3.3": {
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dependencies": [
         "assertion-error",
         "check-error",
@@ -903,8 +1211,8 @@
         "readdirp"
       ]
     },
-    "ci-info@4.1.0": {
-      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A=="
+    "ci-info@4.3.1": {
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="
     },
     "citty@0.1.6": {
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
@@ -924,8 +1232,10 @@
     "cli-table3@0.6.5": {
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dependencies": [
-        "@colors/colors",
         "string-width"
+      ],
+      "optionalDependencies": [
+        "@colors/colors"
       ]
     },
     "cli-truncate@2.1.0": {
@@ -982,8 +1292,8 @@
     "confbox@0.1.8": {
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
     },
-    "consola@3.4.0": {
-      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA=="
+    "consola@3.4.2": {
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
     },
     "cookie-es@1.2.2": {
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
@@ -1009,8 +1319,8 @@
         "which@2.0.2"
       ]
     },
-    "crossws@0.3.3": {
-      "integrity": "sha512-/71DJT3xJlqSnBr83uGJesmVHSzZEvgxHt/fIKxBAAngqMHmnBWQNxCphVxxJ2XL3xleu5+hJD6IQ3TglBedcw==",
+    "crossws@0.3.5": {
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
       "dependencies": [
         "uncrypto"
       ]
@@ -1044,7 +1354,7 @@
         "commander",
         "common-tags",
         "dayjs",
-        "debug@4.4.0",
+        "debug@4.4.3",
         "enquirer",
         "eventemitter2",
         "execa@4.1.0",
@@ -1064,13 +1374,15 @@
         "process",
         "proxy-from-env",
         "request-progress",
-        "semver@7.7.1",
+        "semver@7.7.2",
         "supports-color@8.1.1",
         "tmp",
         "tree-kill",
         "untildify",
         "yauzl"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
     "dashdash@1.14.1": {
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
@@ -1102,8 +1414,8 @@
         "is-data-view"
       ]
     },
-    "dayjs@1.11.13": {
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+    "dayjs@1.11.18": {
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA=="
     },
     "debug@3.2.7": {
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
@@ -1111,8 +1423,8 @@
         "ms"
       ]
     },
-    "debug@4.4.0": {
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
@@ -1142,11 +1454,12 @@
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
-    "destr@2.0.3": {
-      "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
+    "destr@2.0.5": {
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
     },
     "detect-libc@1.0.3": {
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": true
     },
     "dprint-node@1.0.8": {
       "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
@@ -1175,8 +1488,8 @@
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "end-of-stream@1.4.4": {
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+    "end-of-stream@1.4.5": {
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": [
         "once"
       ]
@@ -1191,14 +1504,14 @@
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
-    "error-ex@1.3.2": {
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+    "error-ex@1.3.4": {
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dependencies": [
         "is-arrayish"
       ]
     },
-    "es-abstract@1.23.9": {
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+    "es-abstract@1.24.0": {
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
       "dependencies": [
         "array-buffer-byte-length",
         "arraybuffer.prototype.slice",
@@ -1227,7 +1540,9 @@
         "is-array-buffer",
         "is-callable",
         "is-data-view",
+        "is-negative-zero",
         "is-regex",
+        "is-set",
         "is-shared-array-buffer",
         "is-string",
         "is-typed-array",
@@ -1242,6 +1557,7 @@
         "safe-push-apply",
         "safe-regex-test",
         "set-proto",
+        "stop-iteration-iterator",
         "string.prototype.trim",
         "string.prototype.trimend",
         "string.prototype.trimstart",
@@ -1259,8 +1575,8 @@
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "es-module-lexer@1.6.0": {
-      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
+    "es-module-lexer@1.7.0": {
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
     },
     "es-object-atoms@1.1.1": {
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
@@ -1287,33 +1603,68 @@
     },
     "esbuild@0.24.2": {
       "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
-      "dependencies": [
-        "@esbuild/aix-ppc64",
-        "@esbuild/android-arm",
-        "@esbuild/android-arm64",
-        "@esbuild/android-x64",
-        "@esbuild/darwin-arm64",
-        "@esbuild/darwin-x64",
-        "@esbuild/freebsd-arm64",
-        "@esbuild/freebsd-x64",
-        "@esbuild/linux-arm",
-        "@esbuild/linux-arm64",
-        "@esbuild/linux-ia32",
-        "@esbuild/linux-loong64",
-        "@esbuild/linux-mips64el",
-        "@esbuild/linux-ppc64",
-        "@esbuild/linux-riscv64",
-        "@esbuild/linux-s390x",
-        "@esbuild/linux-x64",
-        "@esbuild/netbsd-arm64",
-        "@esbuild/netbsd-x64",
-        "@esbuild/openbsd-arm64",
-        "@esbuild/openbsd-x64",
-        "@esbuild/sunos-x64",
-        "@esbuild/win32-arm64",
-        "@esbuild/win32-ia32",
-        "@esbuild/win32-x64"
-      ]
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64@0.24.2",
+        "@esbuild/android-arm@0.24.2",
+        "@esbuild/android-arm64@0.24.2",
+        "@esbuild/android-x64@0.24.2",
+        "@esbuild/darwin-arm64@0.24.2",
+        "@esbuild/darwin-x64@0.24.2",
+        "@esbuild/freebsd-arm64@0.24.2",
+        "@esbuild/freebsd-x64@0.24.2",
+        "@esbuild/linux-arm@0.24.2",
+        "@esbuild/linux-arm64@0.24.2",
+        "@esbuild/linux-ia32@0.24.2",
+        "@esbuild/linux-loong64@0.24.2",
+        "@esbuild/linux-mips64el@0.24.2",
+        "@esbuild/linux-ppc64@0.24.2",
+        "@esbuild/linux-riscv64@0.24.2",
+        "@esbuild/linux-s390x@0.24.2",
+        "@esbuild/linux-x64@0.24.2",
+        "@esbuild/netbsd-arm64@0.24.2",
+        "@esbuild/netbsd-x64@0.24.2",
+        "@esbuild/openbsd-arm64@0.24.2",
+        "@esbuild/openbsd-x64@0.24.2",
+        "@esbuild/sunos-x64@0.24.2",
+        "@esbuild/win32-arm64@0.24.2",
+        "@esbuild/win32-ia32@0.24.2",
+        "@esbuild/win32-x64@0.24.2"
+      ],
+      "scripts": true,
+      "bin": true
+    },
+    "esbuild@0.25.10": {
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64@0.25.10",
+        "@esbuild/android-arm@0.25.10",
+        "@esbuild/android-arm64@0.25.10",
+        "@esbuild/android-x64@0.25.10",
+        "@esbuild/darwin-arm64@0.25.10",
+        "@esbuild/darwin-x64@0.25.10",
+        "@esbuild/freebsd-arm64@0.25.10",
+        "@esbuild/freebsd-x64@0.25.10",
+        "@esbuild/linux-arm@0.25.10",
+        "@esbuild/linux-arm64@0.25.10",
+        "@esbuild/linux-ia32@0.25.10",
+        "@esbuild/linux-loong64@0.25.10",
+        "@esbuild/linux-mips64el@0.25.10",
+        "@esbuild/linux-ppc64@0.25.10",
+        "@esbuild/linux-riscv64@0.25.10",
+        "@esbuild/linux-s390x@0.25.10",
+        "@esbuild/linux-x64@0.25.10",
+        "@esbuild/netbsd-arm64@0.25.10",
+        "@esbuild/netbsd-x64@0.25.10",
+        "@esbuild/openbsd-arm64@0.25.10",
+        "@esbuild/openbsd-x64@0.25.10",
+        "@esbuild/openharmony-arm64",
+        "@esbuild/sunos-x64@0.25.10",
+        "@esbuild/win32-arm64@0.25.10",
+        "@esbuild/win32-ia32@0.25.10",
+        "@esbuild/win32-x64@0.25.10"
+      ],
+      "scripts": true,
+      "bin": true
     },
     "escape-string-regexp@1.0.5": {
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
@@ -1364,8 +1715,8 @@
         "pify@2.3.0"
       ]
     },
-    "expect-type@1.1.0": {
-      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA=="
+    "expect-type@1.2.2": {
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="
     },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
@@ -1373,22 +1724,34 @@
     "extract-zip@2.0.1": {
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": [
-        "@types/yauzl",
-        "debug@4.4.0",
+        "debug@4.4.3",
         "get-stream@5.2.0",
         "yauzl"
-      ]
+      ],
+      "optionalDependencies": [
+        "@types/yauzl"
+      ],
+      "bin": true
     },
     "extsprintf@1.3.0": {
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
-    "fast-equals@5.2.2": {
-      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="
+    "fast-equals@5.3.2": {
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ=="
     },
     "fd-slicer@1.1.0": {
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dependencies": [
         "pend"
+      ]
+    },
+    "fdir@6.5.0_picomatch@4.0.3": {
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dependencies": [
+        "picomatch@4.0.3"
+      ],
+      "optionalPeers": [
+        "picomatch@4.0.3"
       ]
     },
     "figures@3.2.0": {
@@ -1409,8 +1772,8 @@
         "to-regex-range"
       ]
     },
-    "for-each@0.3.4": {
-      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+    "for-each@0.3.5": {
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dependencies": [
         "is-callable"
       ]
@@ -1418,11 +1781,13 @@
     "forever-agent@0.6.1": {
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
-    "form-data@4.0.1": {
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+    "form-data@4.0.4": {
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": [
         "asynckit",
         "combined-stream",
+        "es-set-tostringtag",
+        "hasown",
         "mime-types"
       ]
     },
@@ -1436,7 +1801,9 @@
       ]
     },
     "fsevents@2.3.3": {
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": ["darwin"],
+      "scripts": true
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
@@ -1455,8 +1822,11 @@
     "functions-have-names@1.2.3": {
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
-    "get-intrinsic@1.2.7": {
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+    "generator-function@2.0.1": {
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": [
         "call-bind-apply-helpers",
         "es-define-property",
@@ -1470,8 +1840,8 @@
         "math-intrinsics"
       ]
     },
-    "get-port-please@3.1.2": {
-      "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
+    "get-port-please@3.2.0": {
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="
     },
     "get-port@7.1.0": {
       "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw=="
@@ -1531,8 +1901,8 @@
     "graceful-fs@4.2.11": {
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "h3@1.15.0": {
-      "integrity": "sha512-OsjX4JW8J4XGgCgEcad20pepFQWnuKH+OwkCJjogF3C+9AZ1iYdtB4hX6vAb5DskBiu5ljEXqApINjR8CqoCMQ==",
+    "h3@1.15.4": {
+      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
       "dependencies": [
         "cookie-es",
         "crossws",
@@ -1540,7 +1910,6 @@
         "destr",
         "iron-webcrypto",
         "node-mock-http",
-        "ohash",
         "radix3",
         "ufo",
         "uncrypto"
@@ -1605,8 +1974,8 @@
     "ieee754@1.2.1": {
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
-    "immutable@5.0.3": {
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
+    "immutable@5.1.3": {
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg=="
     },
     "indent-string@4.0.0": {
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
@@ -1684,7 +2053,8 @@
       ]
     },
     "is-docker@3.0.0": {
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": true
     },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
@@ -1698,10 +2068,11 @@
     "is-fullwidth-code-point@3.0.0": {
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
-    "is-generator-function@1.1.0": {
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+    "is-generator-function@1.1.2": {
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dependencies": [
         "call-bound",
+        "generator-function",
         "get-proto",
         "has-tostringtag",
         "safe-regex-test"
@@ -1717,7 +2088,8 @@
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dependencies": [
         "is-docker"
-      ]
+      ],
+      "bin": true
     },
     "is-installed-globally@0.4.0": {
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
@@ -1728,6 +2100,9 @@
     },
     "is-map@2.0.3": {
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
+    },
+    "is-negative-zero@2.0.3": {
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="
     },
     "is-number-object@1.1.1": {
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
@@ -1830,17 +2205,21 @@
     "isstream@0.1.2": {
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "jake@10.9.2": {
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+    "jake@10.9.4": {
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dependencies": [
         "async",
-        "chalk@4.1.2",
         "filelist",
-        "minimatch@3.1.2"
-      ]
+        "picocolors"
+      ],
+      "bin": true
     },
-    "jiti@2.4.2": {
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="
+    "jiti@2.6.1": {
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "bin": true
+    },
+    "js-tokens@9.0.1": {
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="
     },
     "jsbn@0.1.1": {
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
@@ -1855,13 +2234,16 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5@2.2.3": {
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": true
     },
-    "jsonfile@6.1.0": {
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+    "jsonfile@6.2.0": {
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dependencies": [
-        "graceful-fs",
         "universalify"
+      ],
+      "optionalDependencies": [
+        "graceful-fs"
       ]
     },
     "jsprim@2.0.2": {
@@ -1897,7 +2279,8 @@
         "ufo",
         "untun",
         "uqr"
-      ]
+      ],
+      "bin": true
     },
     "listr2@3.14.0_enquirer@2.4.1": {
       "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
@@ -1911,6 +2294,9 @@
         "rxjs",
         "through",
         "wrap-ansi@7.0.0"
+      ],
+      "optionalPeers": [
+        "enquirer"
       ]
     },
     "load-json-file@4.0.0": {
@@ -1944,11 +2330,11 @@
         "wrap-ansi@6.2.0"
       ]
     },
-    "loupe@3.1.3": {
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="
+    "loupe@3.2.1": {
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="
     },
-    "magic-string@0.30.17": {
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+    "magic-string@0.30.19": {
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
       "dependencies": [
         "@jridgewell/sourcemap-codec"
       ]
@@ -1966,7 +2352,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": [
         "braces",
-        "picomatch"
+        "picomatch@2.3.1"
       ]
     },
     "mime-db@1.52.0": {
@@ -1987,23 +2373,23 @@
     "minimatch@3.1.2": {
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": [
-        "brace-expansion@1.1.11"
+        "brace-expansion@1.1.12"
       ]
     },
     "minimatch@5.1.6": {
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": [
-        "brace-expansion@2.0.1"
+        "brace-expansion@2.0.2"
       ]
     },
     "minimist@1.2.8": {
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
-    "mlly@1.7.4": {
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+    "mlly@1.8.0": {
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
       "dependencies": [
         "acorn",
-        "pathe@2.0.2",
+        "pathe@2.0.3",
         "pkg-types",
         "ufo"
       ]
@@ -2011,11 +2397,9 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "nanoid@3.3.8": {
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
-    },
-    "napi-wasm@1.1.3": {
-      "integrity": "sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg=="
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "bin": true
     },
     "nice-try@1.0.5": {
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
@@ -2026,8 +2410,8 @@
     "node-forge@1.3.1": {
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
-    "node-mock-http@1.0.0": {
-      "integrity": "sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ=="
+    "node-mock-http@1.0.3": {
+      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog=="
     },
     "normalize-package-data@2.5.0": {
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
@@ -2050,7 +2434,8 @@
         "read-pkg",
         "shell-quote",
         "string.prototype.padend"
-      ]
+      ],
+      "bin": true
     },
     "npm-run-path@4.0.1": {
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -2080,9 +2465,6 @@
         "has-symbols",
         "object-keys"
       ]
-    },
-    "ohash@1.1.4": {
-      "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
     },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
@@ -2150,11 +2532,11 @@
     "pathe@1.1.2": {
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
     },
-    "pathe@2.0.2": {
-      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w=="
+    "pathe@2.0.3": {
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
-    "pathval@2.0.0": {
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA=="
+    "pathval@2.0.1": {
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="
     },
     "pend@1.2.0": {
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
@@ -2168,8 +2550,12 @@
     "picomatch@2.3.1": {
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
+    "picomatch@4.0.3": {
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+    },
     "pidtree@0.3.1": {
-      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA=="
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "bin": true
     },
     "pify@2.3.0": {
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
@@ -2182,14 +2568,14 @@
       "dependencies": [
         "confbox",
         "mlly",
-        "pathe@2.0.2"
+        "pathe@2.0.3"
       ]
     },
-    "possible-typed-array-names@1.0.0": {
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+    "possible-typed-array-names@1.1.0": {
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
-    "postcss@8.5.1": {
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+    "postcss@8.5.6": {
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dependencies": [
         "nanoid",
         "picocolors",
@@ -2205,15 +2591,15 @@
     "proxy-from-env@1.0.0": {
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A=="
     },
-    "pump@3.0.2": {
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+    "pump@3.0.3": {
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dependencies": [
         "end-of-stream",
         "once"
       ]
     },
-    "qs@6.13.1": {
-      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+    "qs@6.14.0": {
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dependencies": [
         "side-channel"
       ]
@@ -2229,8 +2615,8 @@
         "path-type"
       ]
     },
-    "readdirp@4.1.1": {
-      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw=="
+    "readdirp@4.1.2": {
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
     "reflect.getprototypeof@1.0.10": {
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
@@ -2274,7 +2660,8 @@
         "is-core-module",
         "path-parse",
         "supports-preserve-symlinks-flag"
-      ]
+      ],
+      "bin": true
     },
     "restore-cursor@3.1.0": {
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
@@ -2286,9 +2673,12 @@
     "rfdc@1.4.1": {
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
-    "rollup@4.34.4": {
-      "integrity": "sha512-spF66xoyD7rz3o08sHP7wogp1gZ6itSq22SGa/IZTcUDXDlOyrShwMwkVSB+BUxFRZZCUYqdb3KWDEOMVQZxuw==",
+    "rollup@4.52.4": {
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dependencies": [
+        "@types/estree"
+      ],
+      "optionalDependencies": [
         "@rollup/rollup-android-arm-eabi",
         "@rollup/rollup-android-arm64",
         "@rollup/rollup-darwin-arm64",
@@ -2299,21 +2689,24 @@
         "@rollup/rollup-linux-arm-musleabihf",
         "@rollup/rollup-linux-arm64-gnu",
         "@rollup/rollup-linux-arm64-musl",
-        "@rollup/rollup-linux-loongarch64-gnu",
-        "@rollup/rollup-linux-powerpc64le-gnu",
+        "@rollup/rollup-linux-loong64-gnu",
+        "@rollup/rollup-linux-ppc64-gnu",
         "@rollup/rollup-linux-riscv64-gnu",
+        "@rollup/rollup-linux-riscv64-musl",
         "@rollup/rollup-linux-s390x-gnu",
         "@rollup/rollup-linux-x64-gnu",
         "@rollup/rollup-linux-x64-musl",
+        "@rollup/rollup-openharmony-arm64",
         "@rollup/rollup-win32-arm64-msvc",
         "@rollup/rollup-win32-ia32-msvc",
+        "@rollup/rollup-win32-x64-gnu",
         "@rollup/rollup-win32-x64-msvc",
-        "@types/estree",
         "fsevents"
-      ]
+      ],
+      "bin": true
     },
-    "rxjs@7.8.1": {
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+    "rxjs@7.8.2": {
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dependencies": [
         "tslib"
       ]
@@ -2349,20 +2742,25 @@
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sass@1.84.0": {
-      "integrity": "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==",
+    "sass@1.93.2": {
+      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dependencies": [
-        "@parcel/watcher",
         "chokidar",
         "immutable",
         "source-map-js"
-      ]
+      ],
+      "optionalDependencies": [
+        "@parcel/watcher"
+      ],
+      "bin": true
     },
     "semver@5.7.2": {
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": true
     },
-    "semver@7.7.1": {
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
+    "semver@7.7.2": {
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": true
     },
     "set-function-length@1.2.2": {
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
@@ -2410,8 +2808,8 @@
     "shebang-regex@3.0.0": {
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
-    "shell-quote@1.8.2": {
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="
+    "shell-quote@1.8.3": {
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
     },
     "side-channel-list@1.0.0": {
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
@@ -2494,8 +2892,8 @@
         "spdx-license-ids"
       ]
     },
-    "spdx-license-ids@3.0.21": {
-      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="
+    "spdx-license-ids@3.0.22": {
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="
     },
     "sshpk@1.18.0": {
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
@@ -2509,13 +2907,21 @@
         "jsbn",
         "safer-buffer",
         "tweetnacl"
-      ]
+      ],
+      "bin": true
     },
     "stackback@0.0.2": {
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
     },
-    "std-env@3.8.0": {
-      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
+    "std-env@3.9.0": {
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
+    },
+    "stop-iteration-iterator@1.1.0": {
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dependencies": [
+        "es-errors",
+        "internal-slot"
+      ]
     },
     "string-width@4.2.3": {
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -2578,6 +2984,12 @@
     "strip-final-newline@3.0.0": {
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
     },
+    "strip-literal@3.1.0": {
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dependencies": [
+        "js-tokens"
+      ]
+    },
     "supports-color@5.5.0": {
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dependencies": [
@@ -2626,26 +3038,34 @@
     "tinyexec@0.3.2": {
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
-    "tinypool@1.0.2": {
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA=="
+    "tinyglobby@0.2.15_picomatch@4.0.3": {
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dependencies": [
+        "fdir",
+        "picomatch@4.0.3"
+      ]
+    },
+    "tinypool@1.1.1": {
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="
     },
     "tinyrainbow@2.0.0": {
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="
     },
-    "tinyspy@3.0.2": {
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="
+    "tinyspy@4.0.4": {
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="
     },
-    "tldts-core@6.1.76": {
-      "integrity": "sha512-uzhJ02RaMzgQR3yPoeE65DrcHI6LoM4saUqXOt/b5hmb3+mc4YWpdSeAQqVqRUlQ14q8ZuLRWyBR1ictK1dzzg=="
+    "tldts-core@6.1.86": {
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
     },
-    "tldts@6.1.76": {
-      "integrity": "sha512-6U2ti64/nppsDxQs9hw8ephA3nO6nSQvVVfxwRw8wLQPFtLI1cFI1a1eP22g+LUP+1TA2pKKjUTwWB+K2coqmQ==",
+    "tldts@6.1.86": {
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dependencies": [
         "tldts-core"
-      ]
+      ],
+      "bin": true
     },
-    "tmp@0.2.3": {
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
+    "tmp@0.2.5": {
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -2653,14 +3073,15 @@
         "is-number"
       ]
     },
-    "tough-cookie@5.1.0": {
-      "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
+    "tough-cookie@5.1.2": {
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dependencies": [
         "tldts"
       ]
     },
     "tree-kill@1.2.2": {
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "bin": true
     },
     "ts-pattern@5.6.2": {
       "integrity": "sha512-d4IxJUXROL5NCa3amvMg6VQW2HVtZYmUTPfvVtO7zJWGYLJ+mry9v2OmYm+z67aniQoQ8/yFNadiEwtNS9qQiw=="
@@ -2733,8 +3154,8 @@
         "reflect.getprototypeof"
       ]
     },
-    "ufo@1.5.4": {
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+    "ufo@1.6.1": {
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="
     },
     "unbox-primitive@1.1.0": {
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
@@ -2748,11 +3169,8 @@
     "uncrypto@0.1.3": {
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
-    "undici-types@6.19.8": {
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-    },
-    "undici-types@6.20.0": {
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    "undici-types@7.10.0": {
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
     },
     "unique-string@3.0.0": {
       "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
@@ -2772,13 +3190,15 @@
         "citty",
         "consola",
         "pathe@1.1.2"
-      ]
+      ],
+      "bin": true
     },
     "uqr@0.1.2": {
       "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
     },
     "uuid@8.3.2": {
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": true
     },
     "validate-npm-package-license@3.0.4": {
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
@@ -2795,87 +3215,140 @@
         "extsprintf"
       ]
     },
-    "vite-node@3.0.5_sass@1.84.0": {
-      "integrity": "sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==",
+    "vite-node@3.2.4_sass@1.93.2": {
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dependencies": [
         "cac",
-        "debug@4.4.0",
+        "debug@4.4.3",
         "es-module-lexer",
-        "pathe@2.0.2",
-        "vite@6.1.0_sass@1.84.0"
-      ]
+        "pathe@2.0.3",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3"
+      ],
+      "bin": true
     },
-    "vite-plugin-wasm@3.4.1_vite@6.1.0__sass@1.84.0_@types+node@22.5.4_sass@1.84.0": {
-      "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
+    "vite-node@3.2.4_sass@1.93.2_@types+node@24.2.0": {
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dependencies": [
-        "vite@6.1.0_sass@1.84.0_@types+node@22.5.4"
-      ]
+        "cac",
+        "debug@4.4.3",
+        "es-module-lexer",
+        "pathe@2.0.3",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0"
+      ],
+      "bin": true
     },
-    "vite@6.1.0_@types+node@22.5.4_sass@1.84.0": {
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+    "vite@6.3.6_sass@1.93.2_picomatch@4.0.3": {
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dependencies": [
-        "@types/node@22.5.4",
-        "esbuild",
-        "fsevents",
+        "esbuild@0.25.10",
+        "fdir",
+        "picomatch@4.0.3",
         "postcss",
         "rollup",
+        "sass",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
         "sass"
-      ]
+      ],
+      "bin": true
     },
-    "vite@6.1.0_sass@1.84.0": {
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+    "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0": {
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dependencies": [
-        "esbuild",
-        "fsevents",
+        "@types/node",
+        "esbuild@0.25.10",
+        "fdir",
+        "picomatch@4.0.3",
         "postcss",
         "rollup",
+        "sass",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node",
         "sass"
-      ]
+      ],
+      "bin": true
     },
-    "vite@6.1.0_sass@1.84.0_@types+node@22.5.4": {
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+    "vitest@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2": {
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dependencies": [
-        "@types/node@22.5.4",
-        "esbuild",
-        "fsevents",
-        "postcss",
-        "rollup",
-        "sass"
-      ]
-    },
-    "vitest@3.0.5_vite@6.1.0__sass@1.84.0_sass@1.84.0": {
-      "integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
-      "dependencies": [
+        "@types/chai",
         "@vitest/expect",
-        "@vitest/mocker",
+        "@vitest/mocker@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2",
         "@vitest/pretty-format",
         "@vitest/runner",
         "@vitest/snapshot",
         "@vitest/spy",
         "@vitest/utils",
         "chai",
-        "debug@4.4.0",
+        "debug@4.4.3",
         "expect-type",
         "magic-string",
-        "pathe@2.0.2",
+        "pathe@2.0.3",
+        "picomatch@4.0.3",
         "std-env",
         "tinybench",
         "tinyexec",
+        "tinyglobby",
         "tinypool",
         "tinyrainbow",
-        "vite@6.1.0_sass@1.84.0",
-        "vite-node",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3",
+        "vite-node@3.2.4_sass@1.93.2",
         "why-is-node-running"
-      ]
+      ],
+      "bin": true
     },
-    "vue-demi@0.14.10_vue@3.5.13": {
+    "vitest@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0": {
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dependencies": [
+        "@types/chai",
+        "@types/node",
+        "@vitest/expect",
+        "@vitest/mocker@3.2.4_vite@6.3.6__sass@1.93.2__picomatch@4.0.3_sass@1.93.2_@types+node@24.2.0",
+        "@vitest/pretty-format",
+        "@vitest/runner",
+        "@vitest/snapshot",
+        "@vitest/spy",
+        "@vitest/utils",
+        "chai",
+        "debug@4.4.3",
+        "expect-type",
+        "magic-string",
+        "pathe@2.0.3",
+        "picomatch@4.0.3",
+        "std-env",
+        "tinybench",
+        "tinyexec",
+        "tinyglobby",
+        "tinypool",
+        "tinyrainbow",
+        "vite@6.3.6_sass@1.93.2_picomatch@4.0.3_@types+node@24.2.0",
+        "vite-node@3.2.4_sass@1.93.2_@types+node@24.2.0",
+        "why-is-node-running"
+      ],
+      "optionalPeers": [
+        "@types/node"
+      ],
+      "bin": true
+    },
+    "vue-demi@0.14.10_vue@3.5.22": {
       "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "dependencies": [
         "vue"
-      ]
+      ],
+      "scripts": true,
+      "bin": true
     },
-    "vue@3.5.13": {
-      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+    "vue@3.5.22": {
+      "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/compiler-sfc",
@@ -2921,13 +3394,14 @@
         "is-weakset"
       ]
     },
-    "which-typed-array@1.1.18": {
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+    "which-typed-array@1.1.19": {
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dependencies": [
         "available-typed-arrays",
         "call-bind",
         "call-bound",
         "for-each",
+        "get-proto",
         "gopd",
         "has-tostringtag"
       ]
@@ -2936,20 +3410,23 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dependencies": [
         "isexe"
-      ]
+      ],
+      "bin": true
     },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": [
         "isexe"
-      ]
+      ],
+      "bin": true
     },
     "why-is-node-running@2.3.0": {
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dependencies": [
         "siginfo",
         "stackback"
-      ]
+      ],
+      "bin": true
     },
     "wrap-ansi@6.2.0": {
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
@@ -2980,27 +3457,30 @@
         "fd-slicer"
       ]
     },
-    "zx@8.3.2": {
-      "integrity": "sha512-qjTunv1NClO05jDaUjrNZfpqC9yvNCchge/bzOcQevsh1aM5qE3TG6MY24kuQKlOWx+7vNuhqO2wa9nQCIGvZA==",
-      "dependencies": [
-        "@types/fs-extra",
-        "@types/node@22.13.1"
-      ]
+    "zx@8.8.4": {
+      "integrity": "sha512-44GcD+ZlM/v1OQtbwnSxLPcoE1ZEUICmR+RSbJZLAqfIixNLuMjLyh0DcS75OyfJ/sWYAwCWDmDvJ4hdnANAPQ==",
+      "bin": true
     }
   },
   "workspace": {
     "dependencies": [
+      "jsr:@david/dax@~0.43.2",
       "jsr:@std/assert@^1.0.11",
       "jsr:@std/async@^1.0.10",
-      "jsr:@std/encoding@^1.0.7",
+      "jsr:@std/cli@^1.0.22",
+      "jsr:@std/crypto@^1.0.5",
+      "jsr:@std/encoding@^1.0.10",
       "jsr:@std/expect@^1.0.13",
       "jsr:@std/fmt@^1.0.5",
+      "jsr:@std/fs@^1.0.19",
+      "jsr:@std/path@^1.1.2",
       "jsr:@std/testing@^1.0.9",
+      "jsr:@std/text@^1.0.16",
       "jsr:@std/toml@^1.0.2",
       "npm:@deno/vite-plugin@^1.0.3",
       "npm:change-case@^5.4.4",
       "npm:dprint-node@^1.0.8",
-      "npm:fast-equals@^5.2.2",
+      "npm:fast-equals@^5.3.2",
       "npm:get-port@^7.1.0",
       "npm:immutable@^5.0.3",
       "npm:jake@^10.9.2",
@@ -3041,7 +3521,6 @@
             "npm:esbuild@~0.24.2",
             "npm:npm-run-all@^4.1.5",
             "npm:sass@^1.52.1",
-            "npm:vite-plugin-wasm@^3.4.1",
             "npm:vite@^6.1.0",
             "npm:vue@^3.2.47"
           ]

--- a/etc/__snapshots__/codegen_test.ts.snap
+++ b/etc/__snapshots__/codegen_test.ts.snap
@@ -17,7 +17,7 @@ export type QueryCompatibleSelectors = {
   FindPeers: 'peer-id' | 'peer-id-public-key'
   FindActiveTriggerIds: 'trigger-id' | 'trigger-id-name'
   FindTriggers: 'trigger' | 'trigger-id' | 'trigger-id-name' | 'trigger-action' | 'trigger-action-metadata' | 'trigger-action-metadata-key'
-  FindTransactions: 'committed-transaction' | 'committed-transaction-block-hash' | 'committed-transaction-value' | 'committed-transaction-value-hash' | 'committed-transaction-value-authority' | 'committed-transaction-value-authority-domain' | 'committed-transaction-value-authority-domain-name' | 'committed-transaction-value-authority-signatory' | 'committed-transaction-error'
+  FindTransactions: 'committed-transaction' | 'committed-transaction-block-hash' | 'committed-transaction-transaction-entrypoint-hash' | 'committed-transaction-transaction-entrypoint' | 'committed-transaction-transaction-entrypoint-authority' | 'committed-transaction-transaction-entrypoint-authority-domain' | 'committed-transaction-transaction-entrypoint-authority-domain-name' | 'committed-transaction-transaction-entrypoint-authority-signatory' | 'committed-transaction-transaction-result-hash' | 'committed-transaction-transaction-result'
   FindBlocks: 'signed-block' | 'signed-block-header' | 'signed-block-header-hash'
   FindBlockHeaders: 'block-header' | 'block-header-hash'
 }
@@ -78,13 +78,14 @@ export type SelectorIdToOutput = {
   'trigger-action-metadata-key': lib.Json
   'committed-transaction': lib.CommittedTransaction
   'committed-transaction-block-hash': lib.Hash
-  'committed-transaction-value': lib.SignedTransaction
-  'committed-transaction-value-hash': lib.Hash
-  'committed-transaction-value-authority': lib.AccountId
-  'committed-transaction-value-authority-domain': lib.DomainId
-  'committed-transaction-value-authority-domain-name': lib.Name
-  'committed-transaction-value-authority-signatory': lib.PublicKey
-  'committed-transaction-error': lib.Option<lib.TransactionRejectionReason>
+  'committed-transaction-transaction-entrypoint-hash': lib.Hash
+  'committed-transaction-transaction-entrypoint': lib.TransactionEntrypoint
+  'committed-transaction-transaction-entrypoint-authority': lib.AccountId
+  'committed-transaction-transaction-entrypoint-authority-domain': lib.DomainId
+  'committed-transaction-transaction-entrypoint-authority-domain-name': lib.Name
+  'committed-transaction-transaction-entrypoint-authority-signatory': lib.PublicKey
+  'committed-transaction-transaction-result-hash': lib.Hash
+  'committed-transaction-transaction-result': lib.TransactionResult
   'signed-block': lib.SignedBlock
   'signed-block-header': lib.BlockHeader
   'signed-block-header-hash': lib.Hash
@@ -296,26 +297,29 @@ export type QuerySelectors = {
     blockHash: {
       __selector: 'committed-transaction-block-hash',
     }
-    value: {
-      __selector: 'committed-transaction-value',
-      hash: {
-        __selector: 'committed-transaction-value-hash',
-      }
+    transactionEntrypointHash: {
+      __selector: 'committed-transaction-transaction-entrypoint-hash',
+    }
+    transactionEntrypoint: {
+      __selector: 'committed-transaction-transaction-entrypoint',
       authority: {
-        __selector: 'committed-transaction-value-authority',
+        __selector: 'committed-transaction-transaction-entrypoint-authority',
         domain: {
-          __selector: 'committed-transaction-value-authority-domain',
+          __selector: 'committed-transaction-transaction-entrypoint-authority-domain',
           name: {
-            __selector: 'committed-transaction-value-authority-domain-name',
+            __selector: 'committed-transaction-transaction-entrypoint-authority-domain-name',
           }
         }
         signatory: {
-          __selector: 'committed-transaction-value-authority-signatory',
+          __selector: 'committed-transaction-transaction-entrypoint-authority-signatory',
         }
       }
     }
-    error: {
-      __selector: 'committed-transaction-error',
+    transactionResultHash: {
+      __selector: 'committed-transaction-transaction-result-hash',
+    }
+    transactionResult: {
+      __selector: 'committed-transaction-transaction-result',
     }
   }
   FindBlocks: {
@@ -566,10 +570,11 @@ export type QueryPredicates = {
     blockHash: {
       equals: (value: lib.Hash) => lib.CommittedTransactionProjectionPredicate
     }
-    value: {
-      hash: {
-        equals: (value: lib.Hash) => lib.CommittedTransactionProjectionPredicate
-      }
+    transactionEntrypointHash: {
+      equals: (value: lib.Hash) => lib.CommittedTransactionProjectionPredicate
+    }
+    transactionEntrypoint: {
+      isExternal: () => lib.CommittedTransactionProjectionPredicate
       authority: {
         equals: (value: lib.AccountId) => lib.CommittedTransactionProjectionPredicate
         domain: {
@@ -586,8 +591,12 @@ export type QueryPredicates = {
         }
       }
     }
-    error: {
-      isSome: () => lib.CommittedTransactionProjectionPredicate
+    transactionResultHash: {
+      equals: (value: lib.Hash) => lib.CommittedTransactionProjectionPredicate
+    }
+    transactionResult: {
+      isOk: () => lib.CommittedTransactionProjectionPredicate
+      containsDataTrigger: (value: lib.TriggerId) => lib.CommittedTransactionProjectionPredicate
     }
   }
   FindBlocks: {
@@ -684,13 +693,13 @@ export class FindAPI {
   }
 
   /** Convenience method for \`FindBlocks\` query, a variant of {@linkcode types.QueryBox} enum. */
-  public blocks(params?: core.QueryBuilderParams): client.QueryBuilder<'FindBlocks'> {
-    return new client.QueryBuilder(this._executor, 'FindBlocks', params)
+  public blocks(payload: types.FindBlocks, params?: core.QueryBuilderParams): client.QueryBuilder<'FindBlocks'> {
+    return new client.QueryBuilder(this._executor, 'FindBlocks', payload, params)
   }
 
   /** Convenience method for \`FindBlockHeaders\` query, a variant of {@linkcode types.QueryBox} enum. */
-  public blockHeaders(params?: core.QueryBuilderParams): client.QueryBuilder<'FindBlockHeaders'> {
-    return new client.QueryBuilder(this._executor, 'FindBlockHeaders', params)
+  public blockHeaders(payload: types.FindBlockHeaders, params?: core.QueryBuilderParams): client.QueryBuilder<'FindBlockHeaders'> {
+    return new client.QueryBuilder(this._executor, 'FindBlockHeaders', payload, params)
   }
 
   /** Convenience method for \`FindExecutorDataModel\` query, a variant of {@linkcode types.SingularQueryBox} enum. */

--- a/etc/task-codegen.ts
+++ b/etc/task-codegen.ts
@@ -1,7 +1,7 @@
 import SCHEMA from '@iroha/core/data-model/schema-json'
 import { generateClientFindAPI, generateDataModel, generatePrototypes, Resolver } from './codegen.ts'
 import * as colors from '@std/fmt/colors'
-import { parseArgs } from 'jsr:@std/cli/parse-args'
+import { parseArgs } from '@std/cli/parse-args'
 import { assertEquals } from '@std/assert/equals'
 import { fail } from '@std/assert/fail'
 

--- a/etc/task-prep-crypto-wasm.ts
+++ b/etc/task-prep-crypto-wasm.ts
@@ -1,9 +1,9 @@
-import { parseArgs } from 'jsr:@std/cli'
-import * as path from 'jsr:@std/path'
-import $ from 'jsr:@david/dax'
+import { parseArgs } from '@std/cli'
+import * as path from '@std/path'
+import $ from '@david/dax'
 import * as colors from '@std/fmt/colors'
 import { pathRel, resolveFromRoot } from './util.ts'
-import { copy, emptyDir } from 'jsr:@std/fs'
+import { copy, emptyDir } from '@std/fs'
 import { assert } from '@std/assert/assert'
 import { assertEquals } from '@std/assert/equals'
 
@@ -34,7 +34,7 @@ async function checkBuildReady() {
     assertEquals(files, GENERATED_FILES)
     return true
   } catch (err) {
-    $.logWarn('Error whiule checking build artifacts:', err)
+    $.logWarn('Error while checking build artifacts:', err)
     return false
   }
 }

--- a/etc/task-prep-iroha.ts
+++ b/etc/task-prep-iroha.ts
@@ -1,10 +1,10 @@
-import { parseArgs } from 'jsr:@std/cli/parse-args'
+import { parseArgs } from '@std/cli/parse-args'
 import { pathRel, resolveFromRoot } from './util.ts'
-import * as path from 'jsr:@std/path'
-import * as colors from 'jsr:@std/fmt/colors'
-import $ from 'jsr:@david/dax'
+import * as path from '@std/path'
+import * as colors from '@std/fmt/colors'
+import $ from '@david/dax'
 import { assert, assertEquals } from '@std/assert'
-import { copy, emptyDir, ensureDir } from 'jsr:@std/fs'
+import { copy, emptyDir, ensureDir } from '@std/fs'
 
 const IROHA_REPO_DIR = resolveFromRoot('.iroha')
 const PREP_OUTPUT_DIR = resolveFromRoot('prep/iroha')

--- a/etc/task-publish.ts
+++ b/etc/task-publish.ts
@@ -1,4 +1,4 @@
-import $ from 'jsr:@david/dax'
+import $ from '@david/dax'
 import { resolveFromRoot } from './util.ts'
 
 const PATHS = [

--- a/etc/util.ts
+++ b/etc/util.ts
@@ -1,8 +1,8 @@
-import * as path from 'jsr:@std/path'
+import * as path from '@std/path'
 import { assert } from '@std/assert'
-import { expandGlob } from 'jsr:@std/fs'
-import { crypto } from 'jsr:@std/crypto'
-import { encodeHex } from 'jsr:@std/encoding'
+import { expandGlob } from '@std/fs'
+import { crypto } from '@std/crypto'
+import { encodeHex } from '@std/encoding'
 
 export function resolveFromRoot(...paths: (string)[]) {
   const dirname = import.meta.dirname

--- a/packages/client/api.ts
+++ b/packages/client/api.ts
@@ -3,6 +3,7 @@ import { getCodec, type Variant, type VariantUnit } from '@iroha/core'
 import * as dm from '@iroha/core/data-model'
 import type { Schema as DataModelSchema } from '@iroha/core/data-model/schema'
 import {
+  CONTENT_TYPE_SCALE,
   ENDPOINT_CONFIGURATION,
   ENDPOINT_HEALTH,
   ENDPOINT_METRICS,
@@ -153,10 +154,14 @@ export class MainAPI {
   }
 
   public async transaction(transaction: dm.SignedTransaction): Promise<void> {
-    const body = getCodec(dm.SignedTransaction).encode(transaction)
+    const bytes = getCodec(dm.SignedTransaction).encode(transaction)
     const response = await this.http.getFetch()(urlJoinPath(this.http.toriiBaseURL, ENDPOINT_TRANSACTION), {
-      body,
+      // FIXME: some typing issue in Deno? worked fine before
+      body: bytes as unknown as BodyInit,
       method: 'POST',
+      headers: {
+        'Content-Type': CONTENT_TYPE_SCALE,
+      },
     })
     await ResponseError.assertStatus(response, 200)
   }
@@ -165,7 +170,7 @@ export class MainAPI {
     return this.http
       .getFetch()(urlJoinPath(this.http.toriiBaseURL, ENDPOINT_QUERY), {
         method: 'POST',
-        body: getCodec(dm.SignedQuery).encode(query),
+        body: [getCodec(dm.SignedQuery).encode(query)],
       })
       .then(handleQueryResponse)
   }
@@ -246,7 +251,7 @@ export class TelemetryAPI {
 
   public async status(): Promise<dm.Status> {
     const response = await this.http.getFetch()(urlJoinPath(this.http.toriiBaseURL, ENDPOINT_STATUS), {
-      headers: { accept: 'application/x-parity-scale' },
+      headers: { accept: CONTENT_TYPE_SCALE },
     })
     await ResponseError.assertStatus(response, 200)
     return response.arrayBuffer().then((buffer) => getCodec(dm.Status).decode(new Uint8Array(buffer)))

--- a/packages/client/client.ts
+++ b/packages/client/client.ts
@@ -202,6 +202,7 @@ export class TransactionHandle {
         }
       })
       stream.ee.on('close', () => {
+        // FIXME: do not throw on `POST /transaction` rejection
         confirmation.reject(new Error('Events stream was unexpectedly closed'))
       })
       params.verifyAbort?.addEventListener('abort', () => {

--- a/packages/client/const.ts
+++ b/packages/client/const.ts
@@ -10,3 +10,4 @@ export const ENDPOINT_PEERS = '/peers'
 export const ENDPOINT_METRICS = '/metrics'
 
 export const HEALTHY_RESPONSE = `Healthy`
+export const CONTENT_TYPE_SCALE = `application/x-parity-scale`

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -193,7 +193,7 @@
  *    // use selectors and pagination
  *    const items: [types.Hash, types.AccountId][] = await client.find
  *      .transactions()
- *      .selectWith((tx) => [tx.blockHash, tx.value.authority])
+ *      .selectWith((tx) => [tx.blockHash, tx.transactionEntrypoint.authority])
  *      .executeAll()
  * }
  * ```

--- a/packages/client/tests/queries.test-d.ts
+++ b/packages/client/tests/queries.test-d.ts
@@ -53,7 +53,7 @@ type test_find_accs_selector3 = Expect<
 const accountsExecuteAll = await client.find.accounts().executeAll()
 type test_accs_exec_all = Expect<Equal<typeof accountsExecuteAll, types.Account[]>>
 
-const findBlockHeaderHashes = client.find.blockHeaders().selectWith((x) => x.hash)
+const findBlockHeaderHashes = client.find.blockHeaders({ order: types.Order.Ascending }).selectWith((x) => x.hash)
 type test_block_header_hashes = Expect<Equal<BuilderOutput<typeof findBlockHeaderHashes>, types.Hash>>
 
 const findDomainsMetadata = client.find.domains().selectWith((x) => x.metadata)

--- a/packages/core/codec-debug.ts
+++ b/packages/core/codec-debug.ts
@@ -1,0 +1,103 @@
+/**
+ * Dynamic version of the codec based directly on the `schema.json`.
+ *
+ * @module
+ */
+
+import { unreachable } from '@std/assert'
+import * as scale from '@scale-codec/core'
+import { enumCodec, type EnumCodecSchema, GenCodec, nullCodec, structCodec, tupleCodec } from './codec.ts'
+import * as dm from './data-model/mod.ts'
+import SCHEMA from './data-model/schema/json.ts'
+import type { SchemaTypeDefinition } from './data-model/schema/mod.ts'
+import { getCodec } from './data-model/prototypes.generated.prelude.ts'
+
+class Registry {
+  #types = new Map<string, GenCodec<any>>()
+
+  register(key: string, schema: SchemaTypeDefinition) {
+    let codec: GenCodec<any>
+
+    if (schema === null) codec = nullCodec
+    else if (schema === 'String') codec = getCodec(dm.String)
+    else if (typeof schema === 'string') codec = this.#deferred(schema)
+    else if ('Struct' in schema) {
+      codec = structCodec(
+        schema.Struct.map((x) => x.name),
+        schema.Struct.reduce<Record<string, GenCodec<any>>>((acc, def) => {
+          acc[def.name] = this.#deferred(def.type)
+          return acc
+        }, {}),
+      )
+    } else if ('Enum' in schema) {
+      codec = enumCodec(
+        schema.Enum.reduce<EnumCodecSchema<any>>((acc, def) => {
+          acc[def.tag] = def.type ? [def.discriminant, this.#deferred(def.type)] : [def.discriminant]
+          return acc
+        }, {}),
+      )
+    } else if ('Option' in schema) {
+      codec = dm.Option.with(this.#deferred(schema.Option))
+    } else if ('Result' in schema) {
+      codec = enumCodec<{ Ok: [any]; Err: [any] }>({
+        Ok: [0, this.#deferred(schema.Result.ok)],
+        Err: [1, this.#deferred(schema.Result.err)],
+      })
+    } else if ('Int' in schema) {
+      if (schema.Int === 'Compact') codec = getCodec(dm.Compact)
+      else if (schema.Int === 'FixedWidth' && key === 'u8') codec = getCodec(dm.U8)
+      else if (schema.Int === 'FixedWidth' && key === 'u16') codec = getCodec(dm.U16)
+      else if (schema.Int === 'FixedWidth' && key === 'u32') codec = getCodec(dm.U32)
+      else if (schema.Int === 'FixedWidth' && key === 'u64') codec = getCodec(dm.U64)
+      else unreachable(`Unknown int ${key} ${schema.Int}`)
+    } else if ('Map' in schema) {
+      codec = dm.Vec.with(tupleCodec([this.#deferred(schema.Map.key), this.#deferred(schema.Map.value)]))
+    } else if ('Array' in schema) {
+      codec = new GenCodec({
+        encode: scale.encodeFactory<any>(unreachable, unreachable),
+        decode: scale.createArrayDecoder(this.#deferred(schema.Array.type).raw.decode, schema.Array.len),
+      })
+    } else if ('Bitmap' in schema) {
+      if (schema.Bitmap.repr !== 'u32') throw new Error('only u32 bitmaps')
+      codec = getCodec(dm.U32)
+    } else if ('Tuple' in schema) {
+      codec = tupleCodec(schema.Tuple.map((x) => this.#deferred(x)) as any)
+    } else if ('Vec' in schema) {
+      codec = dm.Vec.with(this.#deferred(schema.Vec))
+    } else {
+      const _a: never = schema
+      throw new Error(`unknown schema: ${schema}`)
+    }
+
+    this.#types.set(key, codec!)
+  }
+
+  #deferred(key: string): GenCodec<any> {
+    return GenCodec.lazy(() => this.#get(key))
+  }
+
+  #get(key: string): GenCodec<any> {
+    console.log(`[registry] dispatch ${key}`)
+    const codec = this.#types.get(key)
+    if (!codec) throw new Error(`Could not find codec "${key}"`)
+    return codec
+  }
+
+  decode(key: string, input: string | ArrayBufferView): unknown {
+    return this.#get(key).decode(input)
+  }
+}
+
+const registry = new Registry()
+
+for (const [key, def] of Object.entries(SCHEMA)) {
+  if (key.startsWith('MerkleTree') && def && typeof def !== 'string' && 'Vec' in def) {
+    registry.register(key, { Vec: `Option<${def.Vec}>` })
+  } else {
+    registry.register(key, def)
+  }
+}
+
+export function decode(key: keyof typeof SCHEMA, input: string | ArrayBufferView): unknown {
+  return registry.decode(key, input)
+}

--- a/packages/core/crypto/mod.ts
+++ b/packages/core/crypto/mod.ts
@@ -382,7 +382,7 @@ export class KeyPair implements HasAlgorithm {
   }
 }
 
-export class Signature implements HasPayload {
+export class Signature implements HasPayload, Ord<Signature> {
   public static [SYMBOL_CODEC]: GenCodec<Signature> = getCodec(BytesVec).wrap<Signature>({
     toBase: (higher) => higher.payload.array(),
     fromBase: (lower) => Signature.fromRaw(Bytes.array(lower)),
@@ -435,5 +435,9 @@ export class Signature implements HasPayload {
 
   public toJSON(): string {
     return this.payload.hex()
+  }
+
+  public compare(other: Signature): number {
+    return ordCompare(this.payload.hex(), other.payload.hex())
   }
 }

--- a/packages/core/data-model/compound.ts
+++ b/packages/core/data-model/compound.ts
@@ -505,3 +505,28 @@ export class NftId {
     return this.toString()
   }
 }
+
+export class BlockSignature implements Ord<BlockSignature> {
+  public static [SYMBOL_CODEC]: GenCodec<BlockSignature> = structCodec(['index', 'signature'], {
+    index: getCodec(U64),
+    signature: getCodec(crypto.Signature),
+  }).wrap<BlockSignature>({ toBase: (x) => x, fromBase: (x) => new BlockSignature(x.index, x.signature) })
+
+  public readonly index: bigint
+  public readonly signature: crypto.Signature
+
+  public constructor(index: bigint, signature: crypto.Signature) {
+    this.index = index
+    this.signature = signature
+  }
+
+  public compare(other: BlockSignature): number {
+    const idx = ordCompare(this.index, other.index)
+    if (idx !== 0) return idx
+
+    const signature = this.signature.compare(other.signature)
+    if (signature !== 0) return signature
+
+    return 0
+  }
+}

--- a/packages/core/data-model/mod.ts
+++ b/packages/core/data-model/mod.ts
@@ -76,5 +76,6 @@
 export * from './primitives.ts'
 export * from './compound.ts'
 export * from './types.generated.ts'
+export * from './prototypes.generated.ts'
 export { Hash, KeyPair, PrivateKey, PublicKey, Signature } from '../crypto/mod.ts'
 export type { Variant, VariantUnit } from '../util.ts'

--- a/packages/core/data-model/schema/mod.ts
+++ b/packages/core/data-model/schema/mod.ts
@@ -16,6 +16,7 @@ export type SchemaTypeDefinition =
   | MapDefinition
   | VecDefinition
   | OptionDefinition
+  | ResultDefinition
   | NamedStructDefinition
   | EnumDefinition
   | ArrayDefinition
@@ -49,6 +50,13 @@ export interface ArrayDefinition {
 
 export interface OptionDefinition {
   Option: TypePath
+}
+
+export interface ResultDefinition {
+  Result: {
+    ok: TypePath
+    err: TypePath
+  }
 }
 
 export interface NamedStructDefinition {

--- a/packages/core/deno.jsonc
+++ b/packages/core/deno.jsonc
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./codec": "./codec.ts",
+    "./codec-debug": "./codec-debug.ts",
     "./data-model": "./data-model/mod.ts",
     "./data-model/schema": "./data-model/schema/mod.ts",
     "./data-model/schema-json": "./data-model/schema/json.ts",

--- a/packages/core/query-internal.test.ts
+++ b/packages/core/query-internal.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from '@std/testing/bdd'
 import { expect } from '@std/expect'
 import { getActualSelector, predicateProto, selectorProto } from './query-internal.ts'
 import * as dm from './data-model/mod.ts'
+import { Bytes } from './crypto/util.ts'
 
 describe('predicateProto()', () => {
   function compare<T>(actual: T, expected: T) {
@@ -59,8 +60,18 @@ describe('predicateProto()', () => {
     const proto = predicateProto<'FindTransactions'>()
 
     compare(
-      proto.error.isSome(),
-      dm.CommittedTransactionProjectionPredicate.Error.Atom.IsSome,
+      proto.transactionResult.isOk(),
+      dm.CommittedTransactionProjectionPredicate.TransactionResult.Atom.IsOk,
+    )
+
+    compare(
+      proto.transactionResult.containsDataTrigger(new dm.TriggerId('trig')),
+      dm.CommittedTransactionProjectionPredicate.TransactionResult.Atom.ContainsDataTrigger(new dm.TriggerId('trig')),
+    )
+
+    compare(
+      proto.transactionResultHash.equals(dm.Hash.hash(Bytes.hex('aacc'))),
+      dm.CommittedTransactionProjectionPredicate.TransactionResultHash.Atom.Equals(dm.Hash.hash(Bytes.hex('aacc'))),
     )
 
     compare(
@@ -69,8 +80,8 @@ describe('predicateProto()', () => {
     )
 
     compare(
-      proto.value.authority.domain.name.contains('wuw'),
-      dm.CommittedTransactionProjectionPredicate.Value.Authority.Domain.Name.Atom.Contains('wuw'),
+      proto.transactionEntrypoint.authority.domain.name.contains('wuw'),
+      dm.CommittedTransactionProjectionPredicate.TransactionEntrypoint.Authority.Domain.Name.Atom.Contains('wuw'),
     )
   })
 
@@ -115,10 +126,10 @@ describe('selectorProto()', () => {
     const proto = selectorProto<'FindTransactions'>()
 
     compare(proto, dm.CommittedTransactionProjectionSelector.Atom)
-    compare(proto.error, dm.CommittedTransactionProjectionSelector.Error.Atom)
+    compare(proto.transactionResult, dm.CommittedTransactionProjectionSelector.TransactionResult.Atom)
     compare(
-      proto.value.authority.domain.name,
-      dm.CommittedTransactionProjectionSelector.Value.Authority.Domain.Name.Atom,
+      proto.transactionEntrypoint.authority.domain.name,
+      dm.CommittedTransactionProjectionSelector.TransactionEntrypoint.Authority.Domain.Name.Atom,
     )
     compare(proto.blockHash, dm.CommittedTransactionProjectionSelector.BlockHash.Atom)
   })

--- a/packages/core/query-internal.ts
+++ b/packages/core/query-internal.ts
@@ -4,7 +4,13 @@ import type * as prototypes from './data-model/prototypes.generated.ts'
 import { Name } from './data-model/compound.ts'
 
 export const QUERIES_WITH_PAYLOAD = new Set(
-  ['FindAccountsWithAsset', 'FindPermissionsByAccountId', 'FindRolesByAccountId'] as const,
+  [
+    'FindAccountsWithAsset',
+    'FindPermissionsByAccountId',
+    'FindRolesByAccountId',
+    'FindBlocks',
+    'FindBlockHeaders',
+  ] as const,
 )
 
 // deno-lint-ignore ban-types

--- a/packages/core/query-types.test-d.ts
+++ b/packages/core/query-types.test-d.ts
@@ -39,7 +39,7 @@ type test_find_account_and_id = Expect<
   >
 >
 
-const selectBlocksDefault = new QueryBuilder('FindBlocks')
+const selectBlocksDefault = new QueryBuilder('FindBlocks', { order: types.Order.Ascending })
 type test_default_output_for_blocks = Expect<Equal<BuilderOutput<typeof selectBlocksDefault>, types.SignedBlock>>
 
 type singular_queries_in_output = keyof SingularQueryOutputMap

--- a/packages/core/query.ts
+++ b/packages/core/query.ts
@@ -82,9 +82,9 @@ export class QueryBuilder<Q extends QueryKind, Output = DefaultQueryOutput<Q>> {
    * ```ts
    * import * as types from '@iroha/core/data-model'
    *
-   * const builder: QueryBuilder<'FindTransactions', [types.Hash, null | types.TransactionRejectionReason]> =
-   *   new QueryBuilder('FindTransactions')
-   *     .selectWith((tx) => [tx.value.hash, tx.error])
+   * const builder: QueryBuilder<'FindAssets', [types.Name, types.Numeric]> =
+   *   new QueryBuilder('FindAssets')
+   *     .selectWith((asset) => [asset.id.account.domain, asset.value])
    * ```
    */
   public selectWith<const ProtoTuple>(
@@ -167,7 +167,7 @@ export interface QueryBuilderParams {
 }
 
 function* generateOutputTuples<Output>(response: types.QueryOutputBatchBoxTuple): Generator<Output> {
-  // FIXME: this is redundant in runtime, just a safe guard
+  // NOTE: this is redundant in runtime, just a safe guard
   //   invariant(
   //     response.length === tuple.length,
   //     () => `Expected response to have exactly ${tuple.length} elements, got ${response.length}`,

--- a/tests/browser/cypress/e2e/main.cy.ts
+++ b/tests/browser/cypress/e2e/main.cy.ts
@@ -17,6 +17,14 @@ it('Register new domain and wait until commitment', () => {
   // Ensure that block count is incremented
   cy.contains('Blocks: 4')
 
+  // tx queued + approved, block approved + committed + applied (+ empty block)
+  const EXPECTED_EVENTS = 8
+
   // And all events are caught
-  cy.get('ul.events-list').children('li').should('have.length', 10).last().contains('Block').contains('Applied')
+  cy.get('ul.events-list')
+    .children('li')
+    .should('have.length', EXPECTED_EVENTS)
+    .last()
+    .contains('Block')
+    .contains('Applied')
 })

--- a/tests/browser/deno.jsonc
+++ b/tests/browser/deno.jsonc
@@ -28,9 +28,7 @@
       "dependencies": ["app:dev", "serve-peer", "cy-open"]
     },
     "test": {
-      // FIXME: "vite-plugin-wasm" doesn't work in production, so I have to use `vite dev` in tests
-      // https://github.com/Menci/vite-plugin-wasm/issues/57
-      // "dependencies": ["app:build"],
+      "dependencies": ["app:build"],
       "command": "deno task test:run"
     },
     "test:run": {

--- a/tests/browser/etc/test-run.ts
+++ b/tests/browser/etc/test-run.ts
@@ -1,16 +1,16 @@
-import $ from 'jsr:@david/dax'
+import $ from '@david/dax'
 import { delay, retry } from '@std/async'
 import { PORT_PEER_API, PORT_PEER_P2P, PORT_PEER_SERVER, PORT_VITE } from './meta.ts'
 import { assert } from '@std/assert'
 
-async function spawnLinked(
-  cmd: Deno.Command,
-  check: () => Promise<void>,
-): Promise<{
-  kill: () => Promise<void>
-  // isRunning: () => boolean
+async function spawnLinked(opts: {
+  name: string
+  cmd: Deno.Command
+  check: () => Promise<void>
+}): Promise<{
+  kill: (signal?: Deno.Signal) => Promise<void>
 }> {
-  const child = cmd.spawn()
+  const child = opts.cmd.spawn()
   child.ref()
 
   for (const signal of (['SIGINT', 'SIGTERM', 'SIGQUIT'] satisfies Deno.Signal[])) {
@@ -26,17 +26,16 @@ async function spawnLinked(
   })
 
   await delay(1000)
-  await retry(check)
+  await retry(opts.check)
   assert(running, 'process must not exit until killed')
 
-  // window.addEventListener('')
-
   return {
-    kill: async () => {
-      child.kill()
-      await child.output()
+    kill: async (signal = 'SIGTERM') => {
+      $.logStep(`Killing child: ${opts.name} (${signal})`)
+      child.kill(signal)
+      const output = await child.output()
+      $.logStep(`Child exited: ${opts.name} (code: ${output.code})`)
     },
-    // isRunning: () => running,
   }
 }
 
@@ -65,22 +64,26 @@ await retry(async () => {
 $.logStep('Running peer server and vite preview in parallel')
 const tasks = await Promise.all([
   spawnLinked(
-    new Deno.Command('pnpm', {
-      // TODO: replace with `vite build` & `vite preview` once resolved
-      // https://github.com/Menci/vite-plugin-wasm/issues/57
-      args: ['vite', 'dev', '--port', String(PORT_VITE), '--strictPort'],
-      stderr: 'inherit',
-      'stdout': 'inherit',
-    }),
-    () => assertPortBusy(PORT_VITE),
+    {
+      name: 'vite serve',
+      cmd: new Deno.Command('node_modules/.bin/vite', {
+        args: ['serve', '--port', String(PORT_VITE), '--strictPort'],
+        stderr: 'inherit',
+        stdout: 'inherit',
+      }),
+      check: () => assertPortBusy(PORT_VITE),
+    },
   ),
   spawnLinked(
-    new Deno.Command('deno', {
-      args: ['task', 'serve-peer'],
-      stderr: 'inherit',
-      'stdout': 'inherit',
-    }),
-    () => assertPortBusy(PORT_PEER_SERVER),
+    {
+      name: 'serve-peer',
+      cmd: new Deno.Command('deno', {
+        args: ['task', 'serve-peer'],
+        stderr: 'inherit',
+        stdout: 'inherit',
+      }),
+      check: () => assertPortBusy(PORT_PEER_SERVER),
+    },
   ),
 ])
 $.logStep('Started Vite and Peer server')
@@ -88,7 +91,7 @@ $.logStep('Started Vite and Peer server')
 try {
   $.logStep('Running Cypress')
   await $`pnpm cypress run`
-  $.logStep('Finished Cypress withot errors')
+  $.logStep('Finished Cypress without errors')
 } finally {
   await Promise.all(tasks.map((x) => x.kill()))
   $.logStep('Terminated Vite & Peer server')

--- a/tests/browser/package.json
+++ b/tests/browser/package.json
@@ -11,7 +11,6 @@
     "npm-run-all": "^4.1.5",
     "sass": "^1.52.1",
     "vite": "^6.1.0",
-    "vite-plugin-wasm": "^3.4.1",
     "vue": "^3.2.47"
   },
   "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"

--- a/tests/browser/pnpm-lock.yaml
+++ b/tests/browser/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       vite:
         specifier: ^6.1.0
         version: 6.1.0(@types/node@22.13.1)(sass@1.84.0)(tsx@4.19.2)
-      vite-plugin-wasm:
-        specifier: ^3.4.1
-        version: 3.4.1(vite@6.1.0(@types/node@22.13.1)(sass@1.84.0)(tsx@4.19.2))
       vue:
         specifier: ^3.2.47
         version: 3.5.13(typescript@5.7.3)
@@ -1769,11 +1766,6 @@ packages:
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
-
-  vite-plugin-wasm@3.4.1:
-    resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
-    peerDependencies:
-      vite: ^2 || ^3 || ^4 || ^5 || ^6
 
   vite@6.1.0:
     resolution: {integrity: sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==}
@@ -3653,10 +3645,6 @@ snapshots:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
-
-  vite-plugin-wasm@3.4.1(vite@6.1.0(@types/node@22.13.1)(sass@1.84.0)(tsx@4.19.2)):
-    dependencies:
-      vite: 6.1.0(@types/node@22.13.1)(sass@1.84.0)(tsx@4.19.2)
 
   vite@6.1.0(@types/node@22.13.1)(sass@1.84.0)(tsx@4.19.2):
     dependencies:

--- a/tests/browser/vite.config.ts
+++ b/tests/browser/vite.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import deno from '@deno/vite-plugin'
-import wasm from 'vite-plugin-wasm'
 import { PORT_PEER_API, PORT_PEER_SERVER, PORT_VITE } from './etc/meta.ts'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), deno(), (wasm as any)()],
+  plugins: [vue(), deno()],
   optimizeDeps: {
     esbuildOptions: {
       target: 'esnext',

--- a/tests/node/tests/client-misc.spec.ts
+++ b/tests/node/tests/client-misc.spec.ts
@@ -185,10 +185,12 @@ describe('Queries', () => {
     const { client } = await usePeer()
     await submitTestData(client)
 
-    const blocks: dm.BlockHeader[] = await client.find.blocks().selectWith((block) => block.header).executeAll()
-    const headers: dm.BlockHeader[] = await client.find.blockHeaders().executeAll()
+    const blocks: dm.BlockHeader[] = await client.find
+      .blocks({ order: dm.Order.Descending })
+      .selectWith((block) => block.header).executeAll()
+    const headers: dm.BlockHeader[] = await client.find.blockHeaders({ order: dm.Order.Ascending }).executeAll()
 
-    expect(blocks).toEqual(headers)
+    expect(blocks).toEqual(headers.toReversed())
   })
 
   test('find transactions', async () => {
@@ -355,10 +357,13 @@ describe('Queries', () => {
     const { client } = await usePeer()
     await submitTestData(client)
 
-    const someBlock = (await client.find.blocks().executeAll()).at(1)!
+    const someBlock = (await client.find.blocks({ order: dm.Order.Ascending }, {
+      // exclude genesis block with heavy wasm for debugging purposes
+      offset: 1,
+    }).executeAll()).at(1)!
 
     const found = await client.find
-      .blocks().filterWith((block) =>
+      .blocks({ order: dm.Order.Ascending }).filterWith((block) =>
         dm.CompoundPredicate.Atom(
           block.header.hash.equals(
             blockHash(someBlock.value.payload.header),
@@ -427,10 +432,12 @@ describe('Singular queries', () => {
         },
         "custom": [],
         "executor": {
+          "executionDepth": 3,
           "fuel": 55000000n,
           "memory": 55000000n,
         },
         "smartContract": {
+          "executionDepth": 3,
           "fuel": 55000000n,
           "memory": 55000000n,
         },
@@ -523,7 +530,7 @@ describe('Transactions', () => {
     const hash = tx.hash
     const _found = await client.find
       .transactions()
-      .filterWith((tx) => dm.CompoundPredicate.Atom(tx.value.hash.equals(hash)))
+      .filterWith((tx) => dm.CompoundPredicate.Atom(tx.transactionEntrypointHash.equals(hash)))
       .executeSingle()
 
     // TODO:
@@ -536,13 +543,13 @@ describe('Block Stream API', () => {
   test('Committing 3 blocks one after another', async () => {
     const { client } = await usePeer()
 
-    const stream = await client.blocks({
+    const { stream, ee, stop } = await client.blocks({
       fromBlockHeight: new dm.NonZero(2),
     })
-    const streamClosedPromise = stream.ee.once('close')
+    const streamClosedPromise = ee.once('close')
 
     for (const domainName of ['looking_glass', 'breakdown', 'island']) {
-      const blockPromise = stream.ee.once('block')
+      const blockPromise = stream.next()
 
       await client
         .transaction(
@@ -564,7 +571,7 @@ describe('Block Stream API', () => {
       ])
     }
 
-    await stream.stop()
+    await stop()
   })
 })
 

--- a/tests/node/tests/codec-compat.spec.ts
+++ b/tests/node/tests/codec-compat.spec.ts
@@ -290,20 +290,20 @@ test.each([
     }),
   }),
   defCase({
-    type: 'SortedMap<u64, TransactionRejectionReason>',
-    json: { 1: { WasmExecution: 'whichever' }, 0: { LimitCheck: 'mewo' } },
-    codec: dm.TransactionErrors,
+    type: 'Vec<TransactionResult>',
+    json: [
+      { Ok: [{ id: 'test', instructions: [{ Log: { level: 'TRACE', msg: 'mewo' } }] }] },
+      { Err: { WasmExecution: 'whichever' } },
+      { Err: { LimitCheck: 'mewo' } },
+    ],
+    codec: defineCodec(dm.Vec.with(getCodec(dm.TransactionResult))),
     value: [
-      {
-        index: 1n,
-        error: dm.TransactionRejectionReason.WasmExecution({
-          reason: 'whichever',
-        }),
-      },
-      {
-        index: 0n,
-        error: dm.TransactionRejectionReason.LimitCheck({ reason: 'mewo' }),
-      },
+      dm.TransactionResult.Ok([{
+        id: new dm.TriggerId('test'),
+        instructions: [dm.InstructionBox.Log({ level: dm.Level.TRACE, msg: 'mewo' })],
+      }]),
+      dm.TransactionResult.Err.WasmExecution({ reason: 'whichever' }),
+      dm.TransactionResult.Err.LimitCheck({ reason: 'mewo' }),
     ],
   }),
   // TODO: add SignedBlock

--- a/tests/node/tests/util.ts
+++ b/tests/node/tests/util.ts
@@ -56,7 +56,7 @@ export async function useNetwork(
       const { kill } = await TestPeer.startPeer({
         keypair: key,
         ports,
-        genesis: i === 0 ? genesis : undefined,
+        genesis,
         trustedPeers: trustedPeers(i),
       })
       onTestFinished(kill)

--- a/tests/support/test-configuration/mod.ts
+++ b/tests/support/test-configuration/mod.ts
@@ -7,16 +7,8 @@ export const ACCOUNT_KEY_PAIR = types.KeyPair.fromParts(
   types.PrivateKey.fromMultihash('802620E28031CC65994ADE240E32FCFD0405DF30A47BDD6ABAF76C8C3C5A4F3DE96F75'),
 )
 
-export const GENESIS_KEY_PAIR = types.KeyPair.fromParts(
-  types.PublicKey.fromMultihash('ed01204164BF554923ECE1FD412D241036D863A6AE430476C898248B8237D77534CFC4'),
-  types.PrivateKey.fromMultihash('80262082B3BDE54AEBECA4146257DA0DE8D59D8E46D5FE34887DCD8072866792FCB3AD'),
-)
-
 export const CHAIN = '00000000-0000-0000-0000-000000000000'
 
 export const PEER_CONFIG_BASE = {
   chain: CHAIN,
-  genesis: {
-    public_key: GENESIS_KEY_PAIR.publicKey().multihash(),
-  },
 } as const

--- a/tests/support/test-peer/run.ts
+++ b/tests/support/test-peer/run.ts
@@ -1,5 +1,5 @@
 import { startPeer } from '@iroha/test-peer'
-import * as colors from 'jsr:@std/fmt/colors'
+import * as colors from '@std/fmt/colors'
 import { KeyPair } from '@iroha/core/crypto'
 import { createGenesis } from '@iroha/test-configuration/node'
 


### PR DESCRIPTION
### Upstream changes

- https://github.com/hyperledger-iroha/iroha/pull/5467
	- Added `MerkleProof<T>` struct (no first-class support in `@iroha/core/crypto` yet)
- https://github.com/hyperledger-iroha/iroha/pull/5471
	- Significantly changes the shape of blocks 
- https://github.com/hyperledger-iroha/iroha/pull/5488
	- Mostly internal SDK changes for tests setup
- https://github.com/hyperledger-iroha/iroha/pull/5500
	- Changes `client.ws.blocks()`, returning an `AsyncGenerator<SignedBlock>` (API is not finalized)
- https://github.com/hyperledger-iroha/iroha/pull/5510
	- Methods `client.find.blocks()` and `client.find.blockHeaders()` now require a payload like `{ order: Order.Ascending }`

### Other

- feat(core): provide dynamic schema-based codec in `@iroha/core/codec-debug`
- misc: specify all dependencies in deno config
